### PR TITLE
Slight tweak to the centered code

### DIFF
--- a/scratch/NCP_simple_example.Rmd
+++ b/scratch/NCP_simple_example.Rmd
@@ -1,0 +1,130 @@
+---
+title: "NCP_example"
+author: "Kaitlyn Johnson"
+date: "2024-08-05"
+output: html_document
+---
+The goal of this is to compare the implementation of a very simple fit to
+a centered and non-centered parameterization. In the first example, the
+data will be generated directly from the non-centered parameterization.
+```{r}
+library(rstan)
+library(dplyr)
+```
+
+In the second, it will be nested, with an additional observation model.
+
+To start, let's assume we have a model with priors:
+$$\mu \sim Normal(2,5) $$
+$$ \sigma \sim HalfNormal(0,0.5) $$
+
+$$ y_i \sim Normal(\mu, \sigma) $$
+We generate data with a known mean and standard deviation:
+```{r}
+n_obs <- 10
+true_mean <- 3
+true_sigma <- 0.3
+obs <- rnorm(n_obs, mean = true_mean, sd = true_sigma)
+```
+
+In stan we can write this model as:
+```{r}
+stan_model1_centered <- "
+data {
+  int<lower=1> n_obs;
+  vector[n_obs] obs;
+}
+
+parameters {
+  real mu;
+  real<lower=0> sigma;
+}
+
+
+model {
+  //Priors
+  mu ~ normal(2, 5);
+  sigma ~ normal(0,0.5);
+
+  // Likelihood
+  obs ~ normal(mu, sigma);
+}
+"
+stan_model_cent <- stan_model(
+  model_code = stan_model1_centered
+)
+```
+Fit the centered model
+```{r}
+data_list <- list(
+  n_obs = n_obs,
+  obs = obs
+)
+
+# Fit the model
+fit_cent <- sampling(
+  stan_model_cent,
+  data = data_list,
+  iter = 5000,
+  chains = 1
+)
+```
+Or we can write this model with a non-centered parameterization of:
+
+$$\mu \sim Normal(2,5) $$
+$$ \sigma \sim HalfNormal(0,0.5) $$
+
+Instead of evaluating the observations directly from $Normal(\mu, \sigma)$ we
+add an intermediate step that estimates $\epsilon$ as the draws from a standard normal
+for each such that we have
+
+$$ \epsilon_i \sim Normal(0,1)$$
+
+And finally:
+
+$$ y_i = \mu + \sigma\epsilon_i$$
+
+Which we can write in stan as:
+```{r}
+stan_model1_noncentered <- "
+data {
+  int<lower=1> n_obs;
+  vector[n_obs] obs;
+}
+
+parameters {
+  real mu;
+  real<lower=0> sigma;
+  real<lower=0> sigma_obs;
+  vector[n_obs] eta;
+}
+
+transformed parameters{
+ vector [n_obs] expected_vals = mu + sigma*eta;
+}
+
+
+model {
+  //Priors
+  mu ~ normal(2, 5);
+  sigma ~ normal(0,0.5);
+  eta ~ normal(0,1);
+  sigma_obs ~ normal(0, 0.1);
+
+  // Likelihood
+  obs ~ normal(expected_vals, sigma_obs);
+}
+"
+stan_model_noncent <- stan_model(
+  model_code = stan_model1_noncentered
+)
+```
+# Fit the model
+```{r}
+fit_non_cent <- sampling(
+  stan_model_noncent,
+  data = data_list,
+  iter = 5000,
+  chains = 1
+)
+```

--- a/scratch/NCP_simple_example.Rmd
+++ b/scratch/NCP_simple_example.Rmd
@@ -132,17 +132,14 @@ So in the previous example, we performed a non-centered parameterization on the
 observation model $y_i \sim Normal(mu, sigma)$. Now let's instead suppose
 that we rewrite the model so that $m_i$ is a latent quantity: let's just say it
 is the expected number of medals that individuals on X country's gymnastic team
-will win in any year's Olympics, and the observation model is Negative Binomial
-(has the potential to be highly dispersed, because perhaps most years this
-value is low but on a given year country X might have a great team and have a
-very high number of medals).
+will win in any year's Olympics, and the observation model is Poisson
 Then we have:
 $$\mu \sim Normal(2,5) $$
 
 $$ \sigma \sim HalfNormal(0,0.5) $$
 
 $$ m_i \sim Normal(\mu, \sigma) $$
-$$ y_i \sim NegativeBinomial(\m_i, \phi)$$
+$$ y_i \sim Poisson(m_i)$$
 
 To generate data from this model we now have:
 ```{r}
@@ -165,20 +162,18 @@ data {
 parameters {
   real mu;
   real<lower=0> sigma;
-  real<lower=1e-5>phi;
   vector<lower=0>[n_obs] expected_medals;
 }
+
 
 
 model {
   //Priors
   mu ~ normal(2, 5);
   sigma ~ normal(0,0.5);
-  phi ~ normal(1, 1);
-
   // Likelihood
   expected_medals ~ normal(mu, sigma);
-  obs_medals ~ neg_binomial_2(expected_medals, phi);
+  obs_medals ~ poisson(expected_medals);
 }
 "
 stan_model_cent <- stan_model(
@@ -207,7 +202,6 @@ parameters {
   real mu;
   real<lower=0> sigma;
   vector[n_obs] eta;
-  real<lower=1e-5>phi;
 }
 
 transformed parameters{
@@ -220,10 +214,9 @@ model {
   mu ~ normal(2, 5);
   sigma ~ normal(0,0.5);
   eta ~ normal(0,1);
-  phi ~ normal(1, 1);
 
   // Likelihood
-   obs_medals ~ neg_binomial_2(expected_medals, phi);
+   obs_medals ~ poisson(expected_medals);
 }
 "
 stan_model_noncent <- stan_model(

--- a/scratch/NCP_simple_example.Rmd
+++ b/scratch/NCP_simple_example.Rmd
@@ -22,7 +22,7 @@ $$ \sigma \sim HalfNormal(0,0.5) $$
 $$ y_i \sim Normal(\mu, \sigma) $$
 We generate data with a known mean and standard deviation:
 ```{r}
-n_obs <- 10
+n_obs <- 50
 true_mean <- 3
 true_sigma <- 0.3
 obs <- rnorm(n_obs, mean = true_mean, sd = true_sigma)

--- a/scratch/NCP_simple_example.Rmd
+++ b/scratch/NCP_simple_example.Rmd
@@ -16,6 +16,7 @@ In the second, it will be nested, with an additional observation model.
 
 To start, let's assume we have a model with priors:
 $$\mu \sim Normal(2,5) $$
+
 $$ \sigma \sim HalfNormal(0,0.5) $$
 
 $$ y_i \sim Normal(\mu, \sigma) $$
@@ -120,6 +121,118 @@ stan_model_noncent <- stan_model(
 # Fit the model
 ```{r}
 fit_non_cent <- sampling(
+  stan_model_noncent,
+  data = data_list,
+  iter = 5000,
+  chains = 1
+)
+```
+
+So in the previous example, we performed a non-centered parameterization on the
+observation model $y_i \sim Normal(mu, sigma)$. Now let's instead suppose
+that we rewrite the model so that $m_i$ is a latent quantity: let's just say it
+is the expected number of medals that individuals on X country's gymnastic team
+will win in any year's Olympics, and the observation model is Negative Binomial
+(has the potential to be highly dispersed, because perhaps most years this
+value is low but on a given year country X might have a great team and have a
+very high number of medals).
+Then we have:
+$$\mu \sim Normal(2,5) $$
+
+$$ \sigma \sim HalfNormal(0,0.5) $$
+
+$$ m_i \sim Normal(\mu, \sigma) $$
+$$ y_i \sim NegativeBinomial(\m_i, \phi)$$
+
+To generate data from this model we now have:
+```{r}
+true_phi <- 1
+expected_medals <- rnorm(n_obs, mean = true_mean, sd = true_sigma)
+obs_medals <- rnbinom(n_obs, mu = expected_medals, size = true_phi)
+data_list <- list(
+  n_obs = n_obs,
+  obs_medals = obs_medals
+)
+```
+We write the centered parameterization as:
+```{r}
+stan_model2_centered <- "
+data {
+  int<lower=1> n_obs;
+  array[n_obs] int<lower=0> obs_medals;
+}
+
+parameters {
+  real mu;
+  real<lower=0> sigma;
+  real<lower=1e-5>phi;
+  vector<lower=0>[n_obs] expected_medals;
+}
+
+
+model {
+  //Priors
+  mu ~ normal(2, 5);
+  sigma ~ normal(0,0.5);
+  phi ~ normal(1, 1);
+
+  // Likelihood
+  expected_medals ~ normal(mu, sigma);
+  obs_medals ~ neg_binomial_2(expected_medals, phi);
+}
+"
+stan_model_cent <- stan_model(
+  model_code = stan_model2_centered
+)
+```
+Fit the centered model
+```{r}
+fit_cent <- sampling(
+  stan_model_cent,
+  data = data_list,
+  iter = 5000,
+  chains = 1
+)
+```
+
+Now write the non-centered model
+```{r}
+stan_model2_noncentered <- "
+data {
+  int<lower=1> n_obs;
+  array[n_obs] int<lower=0> obs_medals;
+}
+
+parameters {
+  real mu;
+  real<lower=0> sigma;
+  vector[n_obs] eta;
+  real<lower=1e-5>phi;
+}
+
+transformed parameters{
+ vector [n_obs] expected_medals = mu + sigma*eta;
+}
+
+
+model {
+  //Priors
+  mu ~ normal(2, 5);
+  sigma ~ normal(0,0.5);
+  eta ~ normal(0,1);
+  phi ~ normal(1, 1);
+
+  // Likelihood
+   obs_medals ~ neg_binomial_2(expected_medals, phi);
+}
+"
+stan_model_noncent <- stan_model(
+  model_code = stan_model2_noncentered
+)
+```
+Fit the non-centered parameterization with a negative binomial observation process
+```{r}
+fit_noncent <- sampling(
   stan_model_noncent,
   data = data_list,
   iter = 5000,

--- a/scratch/NCP_simple_example.Rmd
+++ b/scratch/NCP_simple_example.Rmd
@@ -95,7 +95,6 @@ data {
 parameters {
   real mu;
   real<lower=0> sigma;
-  real<lower=0> sigma_obs;
   vector[n_obs] eta;
 }
 
@@ -109,10 +108,9 @@ model {
   mu ~ normal(2, 5);
   sigma ~ normal(0,0.5);
   eta ~ normal(0,1);
-  sigma_obs ~ normal(0, 0.1);
 
   // Likelihood
-  obs ~ normal(expected_vals, sigma_obs);
+  obs ~ normal(expected_vals, 1);
 }
 "
 stan_model_noncent <- stan_model(

--- a/scratch/stan_chol_exmpl.R
+++ b/scratch/stan_chol_exmpl.R
@@ -129,17 +129,15 @@ sigma_matrix_true <- sigma_eps_true^2 * exponential_decay_corr_func_r(list(
   phi = phi_true,
   l = l
 ))
-epsilon_true <- t(mvrnorm(
-  n = n_times,
-  mu = rep(0, n_sites),
-  Sigma = sigma_matrix_true
-))
+# Generate samples from a MVM with mean 0 and covariance matrix sigma
+# epsilon_t ~ MVN(0, sigma_matrix) # nolint
+# for each time point. These are your observations!
 obs_data <- matrix(data = 0, nrow = n_sites, ncol = n_times)
 for (i in 1:n_times) {
   obs_data[, i] <- t(mvrnorm(
     n = 1,
-    mu = epsilon_true[, i],
-    Sigma = diag(1, n_sites)
+    mu = rep(0, n_sites),
+    Sigma = sigma_matrix_true
   ))
 }
 

--- a/scratch/stan_chol_exmpl.R
+++ b/scratch/stan_chol_exmpl.R
@@ -24,6 +24,7 @@ parameters {
   matrix[n_sites,n_times] alpha;
   real<lower=0> phi;
   real<lower=0> sigma_eps;
+  real<lower=0> sigma_obs;
 }
 
 transformed parameters {
@@ -38,13 +39,20 @@ transformed parameters {
 }
 
 model {
+  //Priors
   to_vector(alpha) ~ std_normal();
   phi ~ uniform(0, 50);
   sigma_eps ~ gamma(sqrt(0.1),1);
+  sigma_obs ~ normal(0, 0.1); // Note entirely sure of the magnitude to use
+  // here,
 
   // Likelihood
+  // Assumes normally distributed observation error.
+  // obs_data are your vectors of draws the MVN at each time point (column
+  // bound to produce a matrix). The epsilon matrix are the
+  // mean of the expected realizations of the MVN draws.
   for (i in 1:n_times) {
-    obs_data[,i] ~ multi_normal(epsilon[,i], identity_matrix(n_sites));
+    obs_data[,i] ~ normal(epsilon[,i], sigma_obs);
   }
 }
 "
@@ -80,15 +88,13 @@ transformed parameters {
 }
 
 model {
-  for(i in 1:n_times){
-    epsilon[,i] ~ multi_normal(rep_vector(0, n_sites), Sigma);
-  }
+  //Priors
   phi ~ uniform(0, 50);
   sigma_eps ~ gamma(sqrt(0.1),1);
 
   // Likelihood
   for (i in 1:n_times) {
-    obs_data[,i] ~ multi_normal(epsilon[,i], identity_matrix(n_sites));
+    obs_data[,i] ~ multi_normal(rep_vector(0, n_sites), Sigma);
   }
 }
 "

--- a/scratch/stan_chol_exmpl.R
+++ b/scratch/stan_chol_exmpl.R
@@ -24,7 +24,7 @@ parameters {
   matrix[n_sites,n_times] alpha;
   real<lower=0> phi;
   real<lower=0> sigma_eps;
-  real<lower=0> sigma_obs;
+  //real<lower=0> sigma_obs; Can get rid of this and assume iid normal
 }
 
 transformed parameters {
@@ -43,8 +43,6 @@ model {
   to_vector(alpha) ~ std_normal();
   phi ~ uniform(0, 50);
   sigma_eps ~ gamma(sqrt(0.1),1);
-  sigma_obs ~ normal(0, 0.1); // Note entirely sure of the magnitude to use
-  // here,
 
   // Likelihood
   // Assumes normally distributed observation error.
@@ -52,7 +50,7 @@ model {
   // bound to produce a matrix). The epsilon matrix are the
   // mean of the expected realizations of the MVN draws.
   for (i in 1:n_times) {
-    obs_data[,i] ~ normal(epsilon[,i], sigma_obs);
+    obs_data[,i] ~ normal(epsilon[,i], 1);
   }
 }
 "

--- a/scratch/stan_chol_exmpl.R
+++ b/scratch/stan_chol_exmpl.R
@@ -76,7 +76,6 @@ data {
 }
 
 parameters {
-  matrix[n_sites,n_times] epsilon;
   real<lower=0> phi;
   real<lower=0> sigma_eps;
 }


### PR DESCRIPTION
I now realize why this was very confusing! Because when you do the non-centered parameterization, you generate expectations of the observed data, and these expectations become the mean of your observation model (and I chose normally distributed observation noise here, though I am not sure that is necessarily best practice). 

For the centered paramaterization, you want to write the model in the exact way you are simulating the data which is that:

$$\epsilon_t \sim MVN(0, \Sigma)$$

Where $\Sigma$ is just a function of the data (distance matrix) and the correlation function parameters (`phi` and `sigma_eps`). In this case, you do not have to parameterize the "noise matrix" or the realized draws from the iid normals, because they will go directly into your observation model as part of the likelihood function. 

