### PR TITLE
Update r-cmd-check.yaml

### DIFF
--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -24,7 +24,7 @@ jobs:
       id-token: write
       pages: write
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - uses: r-lib/actions/setup-pandoc@v2
         with:
@@ -52,7 +52,7 @@ jobs:
         shell: Rscript {0}
 
       - name: Upload artifact for GH pages deployment
-        uses: actions/upload-pages-artifact@v2
+        uses: actions/upload-pages-artifact@v4
         with:
           path: "docs/"
 

--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -52,7 +52,7 @@ jobs:
         shell: Rscript {0}
 
       - name: Upload artifact for GH pages deployment
-        uses: actions/upload-pages-artifact@v4
+        uses: actions/upload-pages-artifact@v3
         with:
           path: "docs/"
 

--- a/.github/workflows/r-cmd-check.yaml
+++ b/.github/workflows/r-cmd-check.yaml
@@ -28,4 +28,4 @@ jobs:
       uses: r-lib/actions/check-r-package@v2
       with:
         build_args: 'c("--no-manual", "--no-build-vignettes")'
-        args: 'c("--no-manual", "--as-cran", "--no-vignettes")'
+        args: 'c("--no-manual", "--as-cran", "--ignore-vignettes")'

--- a/.github/workflows/r-cmd-check.yaml
+++ b/.github/workflows/r-cmd-check.yaml
@@ -26,3 +26,6 @@ jobs:
         cmdstan-version: "latest"
     - name: "Check wwinference package"
       uses: r-lib/actions/check-r-package@v2
+      with:
+        args: 'c("--no-manual", "--as-cran", "--no-vignettes")'
+

--- a/.github/workflows/r-cmd-check.yaml
+++ b/.github/workflows/r-cmd-check.yaml
@@ -27,4 +27,5 @@ jobs:
     - name: "Check wwinference package"
       uses: r-lib/actions/check-r-package@v2
       with:
-        args: 'c("--no-manual", "--as-cran", "--no-build-vignettes")'
+        build_args: 'c("--no-manual", "--no-build-vignettes")'
+        args: 'c("--no-manual", "--as-cran", "--no-vignettes")'

--- a/.github/workflows/r-cmd-check.yaml
+++ b/.github/workflows/r-cmd-check.yaml
@@ -27,4 +27,4 @@ jobs:
     - name: "Check wwinference package"
       uses: r-lib/actions/check-r-package@v2
       with:
-        args: 'c("--no-manual", "--as-cran", "--no-vignettes")'
+        args: 'c("--no-manual", "--as-cran", "--no-build-vignettes")'

--- a/.github/workflows/r-cmd-check.yaml
+++ b/.github/workflows/r-cmd-check.yaml
@@ -28,4 +28,3 @@ jobs:
       uses: r-lib/actions/check-r-package@v2
       with:
         args: 'c("--no-manual", "--as-cran", "--no-vignettes")'
-


### PR DESCRIPTION
Since the mandatory website build CI will fail if vignettes cannot be built, we do not need to check them in the `R CMD check` action as well.