### PR TITLE
Change output names

### DIFF
--- a/R/get_draws_df.R
+++ b/R/get_draws_df.R
@@ -15,8 +15,8 @@
 #' class wwinference_fit
 #' @param count_data A dataframe of the preprocessed daily count data (e.g.
 #' hospital admissions) from the "global" population
-#' @param stan_args A list containing all the data passed to stan for fitting
-#' the model
+#' @param stan_data_list A list containing all the data passed to stan for
+#' fitting the model
 #' @param fit_obj a CmdStan object that is the output of fitting the model to
 #' `x` and `count_data`
 #' @param ... additional arguments
@@ -43,7 +43,7 @@ get_draws_df.wwinference_fit <- function(x, ...) {
   get_draws_df.data.frame(
     x = x$raw_input_data$input_ww_data,
     count_data = x$raw_input_data$input_count_data,
-    stan_args = x$stan_data_list,
+    stan_data_list = x$stan_data_list,
     fit_obj = x$fit
   )
 }
@@ -88,8 +88,8 @@ get_draws_df.data.frame <- function(x,
     dplyr::bind_rows(tibble::tibble(
       site = "remainder of pop",
       site_index = max(x$site_index) + 1,
-      site_pop = stan_args$subpop_size[
-        length(unique(stan_args$subpop_size))
+      site_pop = stan_data_list$subpop_size[
+        length(unique(stan_data_list$subpop_size))
       ]
     ))
 

--- a/R/get_draws_df.R
+++ b/R/get_draws_df.R
@@ -41,20 +41,21 @@ get_draws_df <- function(x, ...) {
 #' @export
 get_draws_df.wwinference_fit <- function(x, ...) {
   get_draws_df.data.frame(
-    x = x$input_data$input_ww_data,
-    count_data = x$input_data$input_count_data,
-    stan_args = x$stan_args,
+    x = x$raw_input_data$input_ww_data,
+    count_data = x$raw_input_data$input_count_data,
+    stan_args = x$stan_data_list,
     fit_obj = x$fit
   )
 }
 
-#' @export 
+#' @export
 #' @rdname get_draws_df
 get_draws_df.default <- function(x, ...) {
   stop(
     "No method defined for get_draws_df for object of class(es) ",
-    paste(class(x), collapse = ", "), 
-    ". Use directly on a wwinference_fit object or a dataframe of wastewater observations.",
+    paste(class(x), collapse = ", "),
+    ". Use directly on a wwinference_fit object or a",
+    "dataframe of wastewater observations.",
     call. = FALSE
   )
 }
@@ -62,17 +63,17 @@ get_draws_df.default <- function(x, ...) {
 #' @rdname get_draws_df
 #' @export
 get_draws_df.data.frame <- function(x,
-                                 count_data,
-                                 stan_args,
-                                 fit_obj,
-                                 ...) {
+                                    count_data,
+                                    stan_data_list,
+                                    fit_obj,
+                                    ...) {
   draws <- fit_obj$result$draws()
 
   # Get the necessary mappings needed to join draws to data
   date_time_spine <- tibble::tibble(
     date = seq(
       from = min(count_data$date),
-      to = min(count_data$date) + stan_args$ot + stan_args$ht,
+      to = min(count_data$date) + stan_data_list$ot + stan_data_list$ht,
       by = "days"
     )
   ) |>

--- a/R/get_stan_data.R
+++ b/R/get_stan_data.R
@@ -189,7 +189,7 @@ get_input_ww_data_for_stan <- function(preprocessed_ww_data,
 #'   last_count_data_date,
 #'   calibration_time
 #' )
-#' stan_args <- get_stan_data(
+#' stan_data_list <- get_stan_data(
 #'   input_count_data_for_stan,
 #'   input_ww_data_for_stan,
 #'   forecast_date,
@@ -354,7 +354,7 @@ get_stan_data <- function(input_count_data,
 
   inf_to_count_delay_max <- length(inf_to_count_delay)
 
-  stan_args <- list(
+  stan_data_list <- list(
     gt_max = min(length(generation_interval), params$gt_max),
     hosp_delay_max = inf_to_count_delay_max,
     inf_to_hosp = inf_to_count_delay,
@@ -433,7 +433,7 @@ get_stan_data <- function(input_count_data,
   )
 
 
-  return(stan_args)
+  return(stan_data_list)
 }
 
 #' Get the integer sizes of the wastewater input data

--- a/R/wwinference.R
+++ b/R/wwinference.R
@@ -250,7 +250,7 @@ new_wwinference_fit <- function(
     fit_opts) {
   # Checking
   stopifnot(
-    inherits(fit, "CmdStanMCMC"),
+    inherits(fit$result, what="CmdStanFit"),
     inherits(raw_input_data, "list"),
     inherits(stan_data_list, "list"),
     inherits(fit_opts, "list")

--- a/R/wwinference.R
+++ b/R/wwinference.R
@@ -128,7 +128,7 @@
 #'     infection_feedback_pmf = infection_feedback_pmf,
 #'     params = params
 #'   ),
-#'   mcmc_options = get_mcmc_options(
+#'   fit_opts = get_mcmc_options(
 #'     iter_warmup = 250,
 #'     iter_sampling = 250,
 #'     n_chains = 2
@@ -228,6 +228,7 @@ wwinference <- function(ww_data,
     }
   }
 
+  # Constructs the wwinference_fit class object
   do.call(new_wwinference_fit, out)
 }
 
@@ -285,9 +286,9 @@ print.wwinference_fit <- function(x, ...) {
   cat("--------------------\n")
   cat("For more details, you can access the following:\n")
   cat(" - `$fit` for the CmdStan object\n")
-  cat(" - `$input_data` for the input data\n")
-  cat(" - `$stan_args` for the stan data arguments\n")
-  cat(" - `$mcmc_options` for the MCMC options\n")
+  cat(" - `$raw_input_data` for the input data\n")
+  cat(" - `$stan_data_list` for the stan data arguments\n")
+  cat(" - `$fit_opts` for the fitting options\n")
   invisible(x)
 }
 

--- a/R/wwinference.R
+++ b/R/wwinference.R
@@ -250,7 +250,7 @@ new_wwinference_fit <- function(
     fit_opts) {
   # Checking
   stopifnot(
-    inherits(fit$result, what="CmdStanFit"),
+    inherits(fit$result, what = "CmdStanFit"),
     inherits(raw_input_data, "list"),
     inherits(stan_data_list, "list"),
     inherits(fit_opts, "list")

--- a/R/wwinference.R
+++ b/R/wwinference.R
@@ -58,7 +58,7 @@
 #' `error`: the error message provided from stan, indicating why the model
 #' failed to run. Note, the model might still run and produce draws even if it
 #' has major model issues. We recommend the user always run the
-#' `check_diagnostics()` function on the `diagnostic_summary` as part of any
+#' `check_diagnostics()` function on the `parameter_diagnostics` as part of any
 #' pipeline to ensure model convergence.
 #' @name wwinference
 #' @family diagnostics

--- a/man/get_draws_df.Rd
+++ b/man/get_draws_df.Rd
@@ -24,11 +24,11 @@ class wwinference_fit}
 \item{count_data}{A dataframe of the preprocessed daily count data (e.g.
 hospital admissions) from the "global" population}
 
+\item{stan_data_list}{A list containing all the data passed to stan for
+fitting the model}
+
 \item{fit_obj}{a CmdStan object that is the output of fitting the model to
 \code{x} and \code{count_data}}
-
-\item{stan_args}{A list containing all the data passed to stan for fitting
-the model}
 }
 \value{
 A tibble containing the full set of posterior draws of the

--- a/man/get_draws_df.Rd
+++ b/man/get_draws_df.Rd
@@ -13,7 +13,7 @@ get_draws_df(x, ...)
 
 \method{get_draws_df}{default}(x, ...)
 
-\method{get_draws_df}{data.frame}(x, count_data, stan_args, fit_obj, ...)
+\method{get_draws_df}{data.frame}(x, count_data, stan_data_list, fit_obj, ...)
 }
 \arguments{
 \item{x}{Either a dataframe of wastewater observations, or an object of
@@ -24,11 +24,11 @@ class wwinference_fit}
 \item{count_data}{A dataframe of the preprocessed daily count data (e.g.
 hospital admissions) from the "global" population}
 
-\item{stan_args}{A list containing all the data passed to stan for fitting
-the model}
-
 \item{fit_obj}{a CmdStan object that is the output of fitting the model to
 \code{x} and \code{count_data}}
+
+\item{stan_args}{A list containing all the data passed to stan for fitting
+the model}
 }
 \value{
 A tibble containing the full set of posterior draws of the

--- a/man/get_model_diagnostic_flags.Rd
+++ b/man/get_model_diagnostic_flags.Rd
@@ -58,7 +58,7 @@ This method overloads the generic get_model_diagnostic_flags function
 specifically for objects of type 'wwinference_fit'.
 }
 \seealso{
-Other diagnostics: 
+Other diagnostics:
 \code{\link{parameter_diagnostics}()},
 \code{\link{wwinference}()}
 }

--- a/man/get_stan_data.Rd
+++ b/man/get_stan_data.Rd
@@ -122,7 +122,7 @@ input_ww_data_for_stan <- get_input_ww_data_for_stan(
   last_count_data_date,
   calibration_time
 )
-stan_args <- get_stan_data(
+stan_data_list <- get_stan_data(
   input_count_data_for_stan,
   input_ww_data_for_stan,
   forecast_date,

--- a/man/parameter_diagnostics.Rd
+++ b/man/parameter_diagnostics.Rd
@@ -17,7 +17,7 @@ Method for printing the CmdStan parameter diagnostics for a
 wwinference_fit_object
 }
 \seealso{
-Other diagnostics: 
+Other diagnostics:
 \code{\link{get_model_diagnostic_flags}()},
 \code{\link{wwinference}()}
 }

--- a/man/wwinference.Rd
+++ b/man/wwinference.Rd
@@ -15,7 +15,7 @@ wwinference(
   calibration_time = 90,
   forecast_horizon = 28,
   model_spec = get_model_spec(),
-  mcmc_options = get_mcmc_options(),
+  fit_opts = get_mcmc_options(),
   generate_initial_values = TRUE,
   compiled_model = compile_model()
 )
@@ -49,8 +49,8 @@ forecast date, to produce forecasts for, default is \code{28}}
 example data provided by the package, but this should be specified by the
 user based on the date they are producing a forecast}
 
-\item{mcmc_options}{The MCMC parameters as defined using
-\code{get_mcmc_options()}.}
+\item{fit_opts}{The fit options, which in this case default to the
+MCMC parameters as defined using \code{get_mcmc_options()}.}
 
 \item{generate_initial_values}{Boolean indicating whether or not to specify
 the initialization of the sampler, default is \code{TRUE}, meaning that
@@ -73,11 +73,11 @@ like extract posterior draws, get diangostic behavior, and plot results
 function will return:
 \code{fit}: The CmdStan object that is returned from the call to
 \code{cmdstanr::sample()}. Can be used to access draws, summary, diagnostics, etc.
-\code{input_data}: a list containing the input \code{ww_data} and the input
+\code{raw_input_data}: a list containing the input \code{ww_data} and the input
 \code{count_data} used in the model.
-\code{stan_data_args}: a list containing the inputs passed directly to the
+\code{stan_data_list}: a list containing the inputs passed directly to the
 stan model
-\code{mcmc_options}: a list of the MCMC specifications passed to stan
+\code{fit_opts}: a list of the MCMC specifications passed to stan
 
 If the model fails to run, a list containing the follow will be returned:
 \code{error}: the error message provided from stan, indicating why the model
@@ -181,7 +181,7 @@ ww_fit <- wwinference(input_ww_data,
 }
 }
 \seealso{
-Other diagnostics: 
+Other diagnostics:
 \code{\link{get_model_diagnostic_flags}()},
 \code{\link{parameter_diagnostics}()}
 }

--- a/man/wwinference.Rd
+++ b/man/wwinference.Rd
@@ -172,7 +172,7 @@ ww_fit <- wwinference(input_ww_data,
     infection_feedback_pmf = infection_feedback_pmf,
     params = params
   ),
-  mcmc_options = get_mcmc_options(
+  fit_opts = get_mcmc_options(
     iter_warmup = 250,
     iter_sampling = 250,
     n_chains = 2

--- a/man/wwinference.Rd
+++ b/man/wwinference.Rd
@@ -83,7 +83,7 @@ If the model fails to run, a list containing the follow will be returned:
 \code{error}: the error message provided from stan, indicating why the model
 failed to run. Note, the model might still run and produce draws even if it
 has major model issues. We recommend the user always run the
-\code{check_diagnostics()} function on the \code{diagnostic_summary} as part of any
+\code{check_diagnostics()} function on the \code{parameter_diagnostics} as part of any
 pipeline to ensure model convergence.
 
 \itemize{

--- a/vignettes/wwinference.Rmd
+++ b/vignettes/wwinference.Rmd
@@ -309,7 +309,7 @@ ww_fit <- wwinference::wwinference(
     infection_feedback_pmf = infection_feedback_pmf,
     params = params
   ),
-  fit_opts = get_mcmc_options(),
+  fit_opts = get_mcmc_options(iter_warmup = 100, iter_sampling = 100),
   compiled_model = model
 )
 ```
@@ -390,7 +390,7 @@ We strongly recommend running diagnostics as a post-processing step on the
 model outputs.
 
 This can be done by passing the output of
-`wwinference()` into the `get_model_diagnostic_flags()`, `diagnostic_summary()`,
+`wwinference()` into the `get_model_diagnostic_flags()`, `parameter_diagnostics()`,
 and `parameter_diagnostics()` functions.
 
 `get_model_diagnostic_flags()` will print out a table of any flags, if any of
@@ -400,12 +400,11 @@ runs, we recommend adjusting as needed (see below)
 
 To further troubleshoot, you can look at
 the diagnostic summary and the diagnostics of the individual parameters using
-the functions `diagnostic_summary()` and `parameter_diagnostics()`
+the `parameter_diagnostics()` function.
 
 ```{r diagnostics-using-S3-methods}
 convergence_flag_df <- get_model_diagnostic_flags(ww_fit)
 print(convergence_flag_df)
-diagnostic_summary(ww_fit)
 parameter_diagnostics(ww_fit)
 ```
 
@@ -417,7 +416,7 @@ Start by passing the stan fit object(`ww_fit$fit$result`) into the
 `get_model_diagnostic_flags()` and adjusting the thresholds if desired.
 
 Then, we recommend looking at the diagnostics summary provided by `CmdStan`,
-which we had wrapped into the `diagnostic_summary()` call above. Lastly,
+which we had wrapped into the `parameter_diagnostics()` call above. Lastly,
 we recommend looking at the individual model parameters provided by `CmdStan`
 to identify which components of the model might be driving the convergence
 issues.
@@ -436,7 +435,7 @@ convergence_flag_df <- get_model_diagnostic_flags(
 )
 # Get the tables using the CmdStan functions via wrappers
 summary(ww_fit)
-diagnostic_summary(ww_fit, quiet = TRUE)
+parameter_diagnostics(ww_fit, quiet = TRUE)
 head(convergence_flag_df)
 ```
 

--- a/vignettes/wwinference.Rmd
+++ b/vignettes/wwinference.Rmd
@@ -309,7 +309,7 @@ ww_fit <- wwinference::wwinference(
     infection_feedback_pmf = infection_feedback_pmf,
     params = params
   ),
-  mcmc_options = get_mcmc_options(),
+  fit_opts = get_mcmc_options(),
   compiled_model = model
 )
 ```
@@ -350,9 +350,9 @@ This is demonstrated below:
 
 ```{r extracting-draws-explicit}
 draws_df_explicit <- get_draws_df(
-  x = ww_fit$input_data$input_ww_data,
-  count_data = ww_fit$input_data$input_count_data,
-  stan_args = ww_fit$stan_args,
+  x = ww_fit$raw_input_data$input_ww_data,
+  count_data = ww_fit$raw_input_data$input_count_data,
+  stan_data_list = ww_fit$stan_data_list,
   fit_obj = ww_fit$fit
 )
 ```
@@ -462,7 +462,7 @@ fit_hosp_only <- wwinference::wwinference(
     include_ww = FALSE,
     params = params
   ),
-  mcmc_options = get_mcmc_options(),
+  fit_opts = get_mcmc_options(),
   compiled_model = model
 )
 ```


### PR DESCRIPTION
@gvegayon This makes the requested changes to the output names as discussed here https://github.com/CDCgov/ww-inference-model/pull/58#discussion_r1730411415. The issue with the `fit` not being recognized as  CmdStanMCMC options is still persisting. I wonder if this should be `fit$result`? Didn't test but can!