### PR TITLE
Kj tweaks to 123

### DIFF
--- a/R/initialization.R
+++ b/R/initialization.R
@@ -94,7 +94,20 @@ get_inits_for_one_chain <- function(stan_data, stdev = 0.01) {
     hosp_wday_effect = to_simplex(abs(
       stats::rnorm(7, 1 / 7, stdev)
     )),
-    infection_feedback = abs(stats::rnorm(1, 500, 20))
+    infection_feedback = abs(stats::rnorm(1, 500, 20)),
+    # Spatial inits
+    log_sigma_generalized = stats::rnorm(1, log(0.01^(n_subpops - 1)), 0.5),
+    log_phi = stats::rnorm(1, log(0.2), 0.1),
+    log_scaling_factor = stats::rnorm(1, log(1), 0.1),
+    non_cent_spatial_dev_ns_mat = matrix(
+      stats::rnorm((n_subpops - 1) * n_weeks,
+        mean = 0,
+        sd = stdev
+      ),
+      (n_subpops - 1),
+      n_weeks
+    ),
+    norm_vec_aux_site = stats::rnorm(1, 0, stdev)
   )
   return(init_list)
 }

--- a/R/initialization.R
+++ b/R/initialization.R
@@ -97,7 +97,7 @@ get_inits_for_one_chain <- function(stan_data, stdev = 0.01) {
     infection_feedback = abs(stats::rnorm(1, 500, 20)),
     # Spatial inits
     log_sigma_generalized = stats::rnorm(1, log(0.01^(n_subpops - 1)), 0.5),
-    log_phi = stats::rnorm(1, log(0.2), 0.1),
+    log_phi = stats::rnorm(1, log(0.05), 0.1),
     log_scaling_factor = stats::rnorm(1, log(1), 0.1),
     non_cent_spatial_dev_ns_mat = matrix(
       stats::rnorm((n_subpops - 1) * n_weeks,

--- a/R/initialization.R
+++ b/R/initialization.R
@@ -109,9 +109,10 @@ get_inits_for_one_chain <- function(stan_data, stdev = 0.01) {
     ),
     norm_vec_aux_site = stats::rnorm(n_weeks, 0, stdev)
   )
-
-  if (stan_data$corr_structure_switch != 0) {
-    init_list <- c(init_list, L_Omega = diag((n_subpops - 1)))
+  # Initialize the cholesky decomposition matrix if inferring
+  # unstructured correlation matrix
+  if (stan_data$corr_structure_switch == 2) {
+    init_list$L_Omega <- diag((n_subpops - 1))
   }
   return(init_list)
 }

--- a/R/initialization.R
+++ b/R/initialization.R
@@ -109,5 +109,9 @@ get_inits_for_one_chain <- function(stan_data, stdev = 0.01) {
     ),
     norm_vec_aux_site = stats::rnorm(n_weeks, 0, stdev)
   )
+
+  if (stan_data$corr_structure_switch != 0) {
+    init_list <- c(init_list, L_Omega = diag((n_subpops - 1)))
+  }
   return(init_list)
 }

--- a/R/initialization.R
+++ b/R/initialization.R
@@ -107,7 +107,7 @@ get_inits_for_one_chain <- function(stan_data, stdev = 0.01) {
       (n_subpops - 1),
       n_weeks
     ),
-    norm_vec_aux_site = stats::rnorm(1, 0, stdev)
+    norm_vec_aux_site = stats::rnorm(n_weeks, 0, stdev)
   )
   return(init_list)
 }

--- a/inst/extdata/example_params.toml
+++ b/inst/extdata/example_params.toml
@@ -3,7 +3,7 @@ uot = 50
 
 [infection_process]
 # spatial params
-log_phi_mu_prior = -0.6931472 # log(0.2)
+log_phi_mu_prior = -2.995732 # log(0.05)
 log_phi_sd_prior = 0.5
 l = 1
 log_sigma_generalized_mu_prior = -5.298317 # log(0.05^4)

--- a/inst/stan/wwinference.stan
+++ b/inst/stan/wwinference.stan
@@ -135,7 +135,6 @@ parameters {
   real<lower=0> sigma_rt; // magnitude of site level variation from state level
   real<lower=0, upper=1> autoreg_rt_site;
   real<lower=0, upper=1> autoreg_p_hosp;
-  matrix[n_subpops, n_weeks] error_site; // matrix of subpopulations
   real<lower=0,upper=1> i_first_obs_over_n; // per capita
   // infection incidence on the day of the first observed infection
   vector[n_subpops] eta_i_first_obs; // z-score on logit scale of site

--- a/vignettes/spatial_wwinference.Rmd
+++ b/vignettes/spatial_wwinference.Rmd
@@ -1303,21 +1303,11 @@ hosp_result_plot <- ggplot(
   geom_ribbon(
     data = hosp_ribbon_data,
     aes(x = date, ymin = lower, ymax = upper, fill = inf_model_type),
-    alpha = 0.2
+    alpha = 0.1
   ) +
   geom_line(
     data = hosp_ribbon_data,
     aes(x = date, y = median, color = inf_model_type),
-    size = 1,
-  ) +
-  geom_line(
-    data = hosp_ribbon_data,
-    aes(x = date, y = lower, color = inf_model_type),
-    size = 1,
-  ) +
-  geom_line(
-    data = hosp_ribbon_data,
-    aes(x = date, y = upper, color = inf_model_type),
     size = 1,
   ) +
   geom_point(
@@ -1382,21 +1372,11 @@ ww_result_plot <- ggplot(
   geom_ribbon(
     data = ww_ribbon_data,
     aes(x = date, ymin = lower, ymax = upper, fill = inf_model_type),
-    alpha = 0.2
+    alpha = 0.1
   ) +
   geom_line(
     data = ww_ribbon_data,
     aes(x = date, y = median, color = inf_model_type),
-    size = 1,
-  ) +
-  geom_line(
-    data = ww_ribbon_data,
-    aes(x = date, y = lower, color = inf_model_type),
-    size = 1,
-  ) +
-  geom_line(
-    data = ww_ribbon_data,
-    aes(x = date, y = upper, color = inf_model_type),
     size = 1,
   ) +
   geom_point(

--- a/vignettes/spatial_wwinference.Rmd
+++ b/vignettes/spatial_wwinference.Rmd
@@ -27,6 +27,7 @@ the value of using spatial components within the model.
 library(wwinference)
 library(dplyr)
 library(tibble)
+library(tidyr)
 library(ggplot2)
 library(patchwork)
 library(ggridges)
@@ -128,7 +129,7 @@ ggplot() +
 # Presets ----------------------------------------------------------------------
 set.seed(1)
 site <- 1:n_sites
-lab <- 1:n_sites
+lab <- rep(1, 4)
 # // ww_pop_sites <- c(5e5, 7.5e5, 3.8e5, 4.5e5, 5.5e5, 3.7e5)#, 6e5, 4e5)
 # // pop_size <- 5e6
 global_rt_sd <- 0
@@ -150,52 +151,58 @@ exp_corr_param <- list(
 sigma_generalized <- 0.01^n_sites
 # ------------------------------------------------------------------------------
 # IID Simulated Data -----------------------------------------------------------
-simulated_data_iid <- wwinference::generate_simulated_data(
-  r_in_weeks = r_in_weeks,
-  n_sites = n_sites,
-  # // site = site,
-  # // lab = lab,
-  # // ww_pop_sites = ww_pop_sites,
-  # // pop_size = pop_size,
-  global_rt_sd = global_rt_sd,
-  use_spatial_corr = TRUE,
-  corr_function = wwinference::independence_corr_func_r,
-  corr_fun_params = list(num_sites = n_sites),
-  sigma_generalized = sigma_generalized,
-  aux_site_bool = TRUE
-)
+simulated_data_iid <- withr::with_seed(1, {
+  wwinference::generate_simulated_data(
+    # r_in_weeks = r_in_weeks, #nolint
+    n_sites = n_sites,
+    site = site,
+    lab = lab,
+    # // ww_pop_sites = ww_pop_sites,
+    # // pop_size = pop_size,
+    global_rt_sd = global_rt_sd,
+    use_spatial_corr = TRUE,
+    corr_function = wwinference::independence_corr_func_r,
+    corr_fun_params = list(num_sites = n_sites),
+    sigma_generalized = sigma_generalized,
+    aux_site_bool = TRUE
+  )
+})
 # ------------------------------------------------------------------------------
 # Exponential Simulated Data ---------------------------------------------------
-simulated_data_exp <- wwinference::generate_simulated_data(
-  r_in_weeks = r_in_weeks,
-  n_sites = n_sites,
-  # // site = site,
-  # // lab = lab,
-  # // ww_pop_sites = ww_pop_sites,
-  # // pop_size = pop_size,
-  global_rt_sd = global_rt_sd,
-  use_spatial_corr = TRUE,
-  corr_function = exponential_decay_corr_func_r,
-  corr_fun_params = exp_corr_param,
-  sigma_generalized = sigma_generalized,
-  aux_site_bool = TRUE
-)
+simulated_data_exp <- withr::with_seed(1, {
+  wwinference::generate_simulated_data(
+    # r_in_weeks = r_in_weeks, #nolint
+    n_sites = n_sites,
+    # // site = site,
+    # // lab = lab,
+    # // ww_pop_sites = ww_pop_sites,
+    # // pop_size = pop_size,
+    global_rt_sd = global_rt_sd,
+    use_spatial_corr = TRUE,
+    corr_function = exponential_decay_corr_func_r,
+    corr_fun_params = exp_corr_param,
+    sigma_generalized = sigma_generalized,
+    aux_site_bool = TRUE
+  )
+})
 # ------------------------------------------------------------------------------
 # Rand. Corr. Matrix Simulated Data --------------------------------------------
-simulated_data_rng_corr_mat <- wwinference::generate_simulated_data(
-  r_in_weeks = r_in_weeks,
-  n_sites = n_sites,
-  # // site = site,
-  # // lab = lab,
-  # // ww_pop_sites = ww_pop_sites,
-  # // pop_size = pop_size,
-  global_rt_sd = global_rt_sd,
-  use_spatial_corr = TRUE,
-  corr_function = wwinference::rand_corr_matrix_func,
-  corr_fun_params = list(n_sites = n_sites, seed = 2024),
-  sigma_generalized = sigma_generalized,
-  aux_site_bool = TRUE
-)
+simulated_data_rng_corr_mat <- withr::with_seed(1, {
+  wwinference::generate_simulated_data(
+    # r_in_weeks = r_in_weeks, #nolint
+    n_sites = n_sites,
+    # // site = site,
+    # // lab = lab,
+    # // ww_pop_sites = ww_pop_sites,
+    # // pop_size = pop_size,
+    global_rt_sd = global_rt_sd,
+    use_spatial_corr = TRUE,
+    corr_function = wwinference::rand_corr_matrix_func,
+    corr_fun_params = list(n_sites = n_sites, seed = 2024),
+    sigma_generalized = sigma_generalized,
+    aux_site_bool = TRUE
+  )
+})
 # ------------------------------------------------------------------------------
 ```
 
@@ -713,6 +720,8 @@ iter_sampling <- 500
 
 ## Fitting iid data
 ```{r warning=FALSE, message=FALSE}
+iter_warmup <- 25
+iter_sampling <- 50
 # IID data to IID model --------------------------------------------------------
 fit_iid_to_iid <- wwinference::wwinference(
   ww_data = ww_data_to_fit_iid,

--- a/vignettes/spatial_wwinference.Rmd
+++ b/vignettes/spatial_wwinference.Rmd
@@ -50,12 +50,12 @@ correlation function based of the following fake locations.
 ## Fake locations
 ```{r}
 set.seed(2024)
-n_sites <- 4
+n_sites <- 6
 fake_locs <- data.frame(
-  x = c(85, 37, 36, 7),
-  y = c(12, 75, 75, 96),
-  # // x = runif(n_sites, 0, 100),
-  # // y = runif(n_sites, 0, 100),
+  # // x = c(85, 37, 36, 7),
+  # // y = c(12, 75, 75, 96),
+  x = runif(n_sites, 0, 100),
+  y = runif(n_sites, 0, 100),
   ID = paste0("Site ", 1:n_sites)
 ) %>%
   mutate(
@@ -89,14 +89,14 @@ fake_locs_plot
 ```
 ## Central Rt Curve
 ```{r}
-# // r_in_weeks = c(
-# //  rep(1.1, 5), rep(0.9, 5),
-# //  0.9 + 0.0005 * (1:16)^2
-# // )
 r_in_weeks <- c(
   rep(1.1, 5), rep(0.9, 5),
-  1 + 0.007 * 1:16
+  0.9 + 0.0005 * (1:16)^2
 )
+# // r_in_weeks <- c(
+# //   rep(1.1, 5), rep(0.9, 5),
+# //   1 + 0.007 * 1:16
+# // )
 lng <- length(r_in_weeks)
 ggplot() +
   geom_line(
@@ -129,9 +129,9 @@ ggplot() +
 # Presets ----------------------------------------------------------------------
 set.seed(1)
 site <- 1:n_sites
-lab <- rep(1, 4)
-# // ww_pop_sites <- c(5e5, 7.5e5, 3.8e5, 4.5e5, 5.5e5, 3.7e5)#, 6e5, 4e5)
-# // pop_size <- 5e6
+lab <- rep(1, n_sites)
+ww_pop_sites <- c(5e5, 7.5e5, 3.8e5, 4.5e5, 5.5e5, 3.7e5) # , 6e5, 4e5)
+pop_size <- 5e6
 global_rt_sd <- 0
 exp_corr_param <- list(
   dist_matrix = as.matrix(
@@ -153,12 +153,12 @@ sigma_generalized <- 0.01^n_sites
 # IID Simulated Data -----------------------------------------------------------
 simulated_data_iid <- withr::with_seed(1, {
   wwinference::generate_simulated_data(
-    # r_in_weeks = r_in_weeks, #nolint
+    r_in_weeks = r_in_weeks, # nolint
     n_sites = n_sites,
     site = site,
     lab = lab,
-    # // ww_pop_sites = ww_pop_sites,
-    # // pop_size = pop_size,
+    ww_pop_sites = ww_pop_sites,
+    pop_size = pop_size,
     global_rt_sd = global_rt_sd,
     use_spatial_corr = TRUE,
     corr_function = wwinference::independence_corr_func_r,
@@ -171,12 +171,12 @@ simulated_data_iid <- withr::with_seed(1, {
 # Exponential Simulated Data ---------------------------------------------------
 simulated_data_exp <- withr::with_seed(1, {
   wwinference::generate_simulated_data(
-    # r_in_weeks = r_in_weeks, #nolint
+    r_in_weeks = r_in_weeks, # nolint
     n_sites = n_sites,
-    # // site = site,
-    # // lab = lab,
-    # // ww_pop_sites = ww_pop_sites,
-    # // pop_size = pop_size,
+    site = site,
+    lab = lab,
+    ww_pop_sites = ww_pop_sites,
+    pop_size = pop_size,
     global_rt_sd = global_rt_sd,
     use_spatial_corr = TRUE,
     corr_function = exponential_decay_corr_func_r,
@@ -189,12 +189,12 @@ simulated_data_exp <- withr::with_seed(1, {
 # Rand. Corr. Matrix Simulated Data --------------------------------------------
 simulated_data_rng_corr_mat <- withr::with_seed(1, {
   wwinference::generate_simulated_data(
-    # r_in_weeks = r_in_weeks, #nolint
+    r_in_weeks = r_in_weeks, # nolint
     n_sites = n_sites,
-    # // site = site,
-    # // lab = lab,
-    # // ww_pop_sites = ww_pop_sites,
-    # // pop_size = pop_size,
+    site = site,
+    lab = lab,
+    ww_pop_sites = ww_pop_sites,
+    pop_size = pop_size,
     global_rt_sd = global_rt_sd,
     use_spatial_corr = TRUE,
     corr_function = wwinference::rand_corr_matrix_func,
@@ -720,8 +720,8 @@ iter_sampling <- 500
 
 ## Fitting iid data
 ```{r warning=FALSE, message=FALSE}
-iter_warmup <- 25
-iter_sampling <- 50
+# // iter_warmup <- 25
+# // iter_sampling <- 50
 # IID data to IID model --------------------------------------------------------
 fit_iid_to_iid <- wwinference::wwinference(
   ww_data = ww_data_to_fit_iid,
@@ -743,11 +743,8 @@ fit_iid_to_iid <- wwinference::wwinference(
   dist_matrix = NULL,
   corr_structure_switch = 0
 )
-```
-
 # ------------------------------------------------------------------------------
 # IID data to Exponential model ------------------------------------------------
-```{r}
 fit_iid_to_exp <- wwinference::wwinference(
   ww_data = ww_data_to_fit_iid,
   count_data = hosp_data_preprocessed_iid,
@@ -864,7 +861,7 @@ fit_exp_to_unstruct <- wwinference::wwinference(
 ```
 
 ## Fitting rand. corr. matrix data
-```{r}
+```{r warning=FALSE, message=FALSE}
 # Rand. Corr. Matrix data to IID model -----------------------------------------
 fit_rand_to_iid <- wwinference::wwinference(
   ww_data = ww_data_to_fit_rng_corr_mat,
@@ -1481,6 +1478,7 @@ global_rt_result_plot <- ggplot(
     breaks = c("Exponential", "Unstructured", "IID"),
     values = c("darkviolet", "deeppink3", "darksalmon")
   ) +
+  scale_y_continuous(trans = "log10") +
   theme_bw()
 # ------------------------------------------------------------------------------
 # Site Rt results --------------------------------------------------------------
@@ -1506,6 +1504,12 @@ site_rt_ribbon_data <- all_pred_draws_df %>%
       replacement = "Site \\1",
       x = subpop,
       ignore.case = "remainder of pop"
+    )
+  ) %>%
+  mutate(
+    subpop = case_when(
+      subpop == "remainder of pop" ~ "Aux",
+      .default = subpop
     )
   )
 site_rt_result_plot <- ggplot() +
@@ -1555,6 +1559,7 @@ site_rt_result_plot <- ggplot() +
     breaks = c("Exponential", "Unstructured", "IID"),
     values = c("darkviolet", "deeppink3", "darksalmon")
   ) +
+  scale_y_continuous(trans = "log10") +
   theme_bw()
 # ------------------------------------------------------------------------------
 
@@ -1567,7 +1572,8 @@ global_rt_result_plot / site_rt_result_plot +
 # IID Correlation Matrix -------------------------------------------------------
 iid_corr_matrix_result_plot <- ggplot(all_corr_matrix_draws_df %>%
   filter(
-    gen_model_type == "IID"
+    gen_model_type == "IID",
+    inf_model_type != "IID"
   )) +
   geom_density_ridges(
     aes(
@@ -1609,7 +1615,8 @@ iid_corr_matrix_result_plot <- ggplot(all_corr_matrix_draws_df %>%
 # Exponential Correlation Matrix -----------------------------------------------
 exp_corr_matrix_result_plot <- ggplot(all_corr_matrix_draws_df %>%
   filter(
-    gen_model_type == "Exponential"
+    gen_model_type == "Exponential",
+    inf_model_type != "IID"
   )) +
   geom_density_ridges(
     aes(
@@ -1651,7 +1658,8 @@ exp_corr_matrix_result_plot <- ggplot(all_corr_matrix_draws_df %>%
 # Rand. Corr. Matrix Correlation Matrix ----------------------------------------
 rand_corr_matrix_result_plot <- ggplot(all_corr_matrix_draws_df %>%
   filter(
-    gen_model_type == "Rand. Corr. Matrix"
+    gen_model_type == "Rand. Corr. Matrix",
+    inf_model_type != "IID"
   )) +
   geom_density_ridges(
     aes(

--- a/vignettes/spatial_wwinference.Rmd
+++ b/vignettes/spatial_wwinference.Rmd
@@ -1439,21 +1439,11 @@ global_rt_result_plot <- ggplot(
   geom_ribbon(
     data = global_rt_ribbon_data,
     aes(x = date, ymin = lower, ymax = upper, fill = inf_model_type),
-    alpha = 0.4
+    alpha = 0.2
   ) +
   geom_line(
     data = global_rt_ribbon_data,
     aes(x = date, y = median, color = inf_model_type),
-    size = 1.25,
-  ) +
-  geom_line(
-    data = global_rt_ribbon_data,
-    aes(x = date, y = lower, color = inf_model_type),
-    size = 1.25,
-  ) +
-  geom_line(
-    data = global_rt_ribbon_data,
-    aes(x = date, y = upper, color = inf_model_type),
     size = 1.25,
   ) +
   geom_hline(
@@ -1522,21 +1512,11 @@ site_rt_result_plot <- ggplot() +
   geom_ribbon(
     data = site_rt_ribbon_data,
     aes(x = date, ymin = lower, ymax = upper, fill = inf_model_type),
-    alpha = 0.4
+    alpha = 0.2
   ) +
   geom_line(
     data = site_rt_ribbon_data,
     aes(x = date, y = median, color = inf_model_type),
-    size = 1.25,
-  ) +
-  geom_line(
-    data = site_rt_ribbon_data,
-    aes(x = date, y = lower, color = inf_model_type),
-    size = 1.25,
-  ) +
-  geom_line(
-    data = site_rt_ribbon_data,
-    aes(x = date, y = upper, color = inf_model_type),
     size = 1.25,
   ) +
   geom_hline(

--- a/vignettes/spatial_wwinference.Rmd
+++ b/vignettes/spatial_wwinference.Rmd
@@ -743,8 +743,11 @@ fit_iid_to_iid <- wwinference::wwinference(
   dist_matrix = NULL,
   corr_structure_switch = 0
 )
+```
+
 # ------------------------------------------------------------------------------
 # IID data to Exponential model ------------------------------------------------
+```{r}
 fit_iid_to_exp <- wwinference::wwinference(
   ww_data = ww_data_to_fit_iid,
   count_data = hosp_data_preprocessed_iid,


### PR DESCRIPTION
Minor tweaks for troubleshooting, mostly making a PR so you can see the differences:
- I reverted back to the R(t) in the generate simulated data function for now (just bc we had something that worked with that, and want to see if that is causing the problem or not)
- I added initialization for the spatial correlation parameters (see `R/initialization.R`). Not having these may have been causing the chain failures you were seeing... 
- I set the all the wastewater observations to be all the same lab for simplicity
- reduced the warmup and sampling iterations to speed things up (you should get both stans diagnostic messages and the `wwinference` package diagnostic messages. The key thing here is that if there are a few (e.g. 11 out of 200) divergences, that's to be expected. If there are a majority of divergent transitions, that points to misspecification or a larger issue we'll want to investigate further. I would ignore the max treedepth diagnostics for now!
- tweaked prior on `log_phi` based on poor fit of exponential model to iid data...
- minor aesthetic changes to plots to remove outer 95% PI lines explicitly (still have ribbon)