### PR TITLE
163 expand R version 

### DIFF
--- a/.github/workflows/r-cmd-check.yaml
+++ b/.github/workflows/r-cmd-check.yaml
@@ -6,37 +6,14 @@ on:
     branches: [main, prod]
 
 jobs:
-  check-package-min-R-version:
+  check-package:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
     - uses: actions/checkout@v4
     - uses: r-lib/actions/setup-r@v2
       with:
-        r-version: "4.1.0"
-        use-public-rspm: true
-        extra-repositories: "https://mc-stan.org/r-packages/"
-    - name: "Set up dependencies for wwinference"
-      uses: r-lib/actions/setup-r-dependencies@v2
-      with:
-        needs: check
-    - name: "Install cmdstan via cmdstanr"
-      uses: epinowcast/actions/install-cmdstan@v1
-      with:
-        cmdstan-version: "latest"
-    - name: "Check wwinference package"
-      uses: r-lib/actions/check-r-package@v2
-      with:
-        build_args: 'c("--no-manual", "--no-build-vignettes")'
-        args: 'c("--no-manual", "--as-cran", "--ignore-vignettes")'
-  check-package-latest-R-version:
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v4
-    - uses: actions/checkout@v4
-    - uses: r-lib/actions/setup-r@v2
-      with:
-        r-version: "release"
+        r-version: ["4.1.0", "release"]
         use-public-rspm: true
         extra-repositories: "https://mc-stan.org/r-packages/"
     - name: "Set up dependencies for wwinference"

--- a/.github/workflows/r-cmd-check.yaml
+++ b/.github/workflows/r-cmd-check.yaml
@@ -13,7 +13,7 @@ jobs:
     - uses: actions/checkout@v4
     - uses: r-lib/actions/setup-r@v2
       with:
-        r-version: "release"
+        r-version: "4.1.0"
         use-public-rspm: true
         extra-repositories: "https://mc-stan.org/r-packages/"
     - name: "Set up dependencies for wwinference"

--- a/.github/workflows/r-cmd-check.yaml
+++ b/.github/workflows/r-cmd-check.yaml
@@ -6,7 +6,7 @@ on:
     branches: [main, prod]
 
 jobs:
-  check-package:
+  check-package-min-R-version:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
@@ -14,6 +14,29 @@ jobs:
     - uses: r-lib/actions/setup-r@v2
       with:
         r-version: "4.1.0"
+        use-public-rspm: true
+        extra-repositories: "https://mc-stan.org/r-packages/"
+    - name: "Set up dependencies for wwinference"
+      uses: r-lib/actions/setup-r-dependencies@v2
+      with:
+        needs: check
+    - name: "Install cmdstan via cmdstanr"
+      uses: epinowcast/actions/install-cmdstan@v1
+      with:
+        cmdstan-version: "latest"
+    - name: "Check wwinference package"
+      uses: r-lib/actions/check-r-package@v2
+      with:
+        build_args: 'c("--no-manual", "--no-build-vignettes")'
+        args: 'c("--no-manual", "--as-cran", "--ignore-vignettes")'
+  check-package-latest-R-version:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - uses: actions/checkout@v4
+    - uses: r-lib/actions/setup-r@v2
+      with:
+        r-version: "release"
         use-public-rspm: true
         extra-repositories: "https://mc-stan.org/r-packages/"
     - name: "Set up dependencies for wwinference"

--- a/.github/workflows/r-cmd-check.yaml
+++ b/.github/workflows/r-cmd-check.yaml
@@ -10,7 +10,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
-    - uses: actions/checkout@v4
     - uses: r-lib/actions/setup-r@v2
       with:
         r-version: ["4.1.0", "release"]

--- a/.github/workflows/r-cmd-check.yaml
+++ b/.github/workflows/r-cmd-check.yaml
@@ -7,13 +7,15 @@ on:
 
 jobs:
   check-package:
+    strategy:
+      matrix:
+        r-version: ["4.1.0", "release"]
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
     - uses: r-lib/actions/setup-r@v2
       with:
-        r-version: "4.1.0"
-        r-version: "release"
+        r-version: ${{matrix.r-version}}
         use-public-rspm: true
         extra-repositories: "https://mc-stan.org/r-packages/"
     - name: "Set up dependencies for wwinference"

--- a/.github/workflows/r-cmd-check.yaml
+++ b/.github/workflows/r-cmd-check.yaml
@@ -12,7 +12,8 @@ jobs:
     - uses: actions/checkout@v4
     - uses: r-lib/actions/setup-r@v2
       with:
-        r-version: ["4.1.0", "release"]
+        r-version: "4.1.0"
+        r-version: "release"
         use-public-rspm: true
         extra-repositories: "https://mc-stan.org/r-packages/"
     - name: "Set up dependencies for wwinference"

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -54,7 +54,7 @@ License: Apache License (>= 2)
 URL: https://github.com/cdcgov/ww-inference-model/, https://cdcgov.github.io/ww-inference-model/
 BugReports: https://github.com/cdcgov/ww-inference-model/issues/
 Depends:
-    R (>= 4.3.0)
+    R (>= 4.1.0)
 SystemRequirements: CmdStan (>=2.35.0)
 Encoding: UTF-8
 Roxygen: list(markdown = TRUE)


### PR DESCRIPTION
Attempting to run install of package with multiple R versions in CI. Not sure if there's a more elegant way to do this, but this seemed to work. I think it would make sense to always test both the minimum and latest R release?