### PR TITLE
fix rendering to katex, add mathcal Rt to vignette

### DIFF
--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -1,3 +1,4 @@
 url: https://cdcgov.github.io/ww-inference-model/
 template:
   bootstrap: 5
+  math-rendering: katex

--- a/vignettes/wwinference.Rmd
+++ b/vignettes/wwinference.Rmd
@@ -374,8 +374,8 @@ nowcasted/forecast quantities look reasonable.
 We will generate a dataframe that we'll call `draws_df`, that contains
 the posterior draws of the estimated, nowcasted, and forecasted expected
 observed hospital admissions and wastewater concentrations, as well as the
-latent variables of interest including the site-level R(t) estimates and the
-state-level R(t) estimate.
+latent variables of interest including the site-level $\mathcal{R}(t)$ estimates and the
+state-level $\mathcal{R}(t)$ estimate.
 
 We can generate this directly on the output of `wwinference()` using:
 ```{r extracting-draws}


### PR DESCRIPTION
Sets the math rendering to `katex`, per solution described here https://github.com/r-lib/pkgdown/issues/1966#issuecomment-2132233271 (thanks @damonbayer for the link)