### PR TITLE
Fix formatting so functions link

### DIFF
--- a/vignettes/wwinference.Rmd
+++ b/vignettes/wwinference.Rmd
@@ -59,8 +59,8 @@ from September 1, 2023 to December 1, 2023, with varying sampling frequencies.
 We will be using this data to produce a forecast of COVID-19 hospital admissions
 as of December 6, 2023. These data are provided as part of the package data.
 
-These data are already in a format that can be used for `wwinference`. For the
-hospital admissions data, it contains:
+These data are already in a format that can be used for the `wwinference` package.
+For the hospital admissions data, it contains:
 
 - a date (column `date`): the date of the observation, in this case, the date
 the hospital admissions occurred
@@ -278,12 +278,12 @@ ww_data_to_fit <- indicate_ww_exclusions(
 # Model specification:
 
 We will need to set some metadata to facilitate model specification.
-*This includes:
-+ forecast date (the date we are making a forecast)
-+ number of days to calibrate the model for
-+ number of days to forecast beyond the forecast date
-+ specification of the generation interval, in this case for COVID-19
-+ specification of the delay from infection to the count data, in this case
+This includes:
+- forecast date (the date we are making a forecast)
+- number of days to calibrate the model for
+- number of days to forecast beyond the forecast date
+- specification of the generation interval, in this case for COVID-19
+- specification of the delay from infection to the count data, in this case
  from infection to COVID-19 hospital admission
 
 ## Calibration time and forecast time
@@ -326,7 +326,7 @@ inf_to_hosp <- wwinference::default_covid_inf_to_hosp
 infection_feedback_pmf <- generation_interval
 ```
 
-We will pass these to the `model_spec()` function of the `wwinference()` model,
+We will pass these to the `get_model_spec()` function of the `wwinference()` model,
 along with the other specified parameters above.
 
 # Precompiling the model
@@ -522,7 +522,7 @@ to identify which components of the model might be driving the convergence
 issues.
 
 For further information on troubleshooting the model diagnostics,
-we recommend the (bayesplot tutorial)[https://mc-stan.org/bayesplot/articles/visual-mcmc-diagnostics.html].
+we recommend the [bayesplot tutorial](https://mc-stan.org/bayesplot/articles/visual-mcmc-diagnostics.html).
 
 ```{r diagnostics-explicit}
 convergence_flag_df <- get_model_diagnostic_flags(

--- a/vignettes/wwinference.Rmd
+++ b/vignettes/wwinference.Rmd
@@ -130,7 +130,7 @@ params <- get_params(
 
 ## Wastewater data pre-processing
 
-The `preprocess_ww_data` function adds the following variables to the original
+The `preprocess_ww_data()` function adds the following variables to the original
 dataset. First, it assigns a unique identifier
 the unique combinations of labs and sites, since this is the unit we will
 use for estimating the observation error in the reported measurements.
@@ -149,7 +149,7 @@ and `lab`, and will return a dataframe with the column names needed to
 pass to the downstream model fitting functions.
 
 ```{r preprocess-ww-data}
-ww_data_preprocessed <- wwinference::preprocess_ww_data(
+ww_data_preprocessed <- preprocess_ww_data(
   ww_data,
   conc_col_name = "log_genome_copies_per_ml",
   lod_col_name = "log_lod"
@@ -163,7 +163,7 @@ below the LOD in upstream pre-processing.
 
 ## Hospital admissions data pre-processing
 
-The `preprocess_hosp_data`  function standardizes the column names of the
+The `preprocess_hosp_data()`  function standardizes the column names of the
 resulting datafame. The user must specify the name of the column containing
 the daily hospital admissions counts and the population size that the hospital
 admissions are coming from (from in this case, a hypothetical US state). The
@@ -172,7 +172,7 @@ return a dataframe with the column names needed to pass to the downstream model
 fitting functions.
 
 ```{r preprocess-hosp-data}
-hosp_data_preprocessed <- wwinference::preprocess_count_data(
+hosp_data_preprocessed <- preprocess_count_data(
   hosp_data,
   count_col_name = "daily_hosp_admits",
   pop_size_col_name = "state_pop"
@@ -269,7 +269,7 @@ we will use the `indicate_ww_exclusions()` function, which will add the
 flagged outliers to the exclude column where indicated.
 
 ```{r indicate-ww-exclusions}
-ww_data_to_fit <- wwinference::indicate_ww_exclusions(
+ww_data_to_fit <- indicate_ww_exclusions(
   ww_data_preprocessed,
   outlier_col_name = "flag_as_ww_outlier",
   remove_outliers = TRUE
@@ -363,7 +363,7 @@ pre-compiled model(`model`) to `wwinference()` where they are combined and
 used to fit the model.
 
 ```{r fitting-model, warning=FALSE, message=FALSE}
-ww_fit <- wwinference::wwinference(
+ww_fit <- wwinference(
   ww_data = ww_data_to_fit,
   count_data = hosp_data_preprocessed,
   forecast_date = forecast_date,
@@ -416,7 +416,7 @@ observed hospital admissions and wastewater concentrations, as well as the
 latent variables of interest including the site-level $\mathcal{R}(t)$ estimates and the
 state-level $\mathcal{R}(t)$ estimate.
 
-We can generate this directly on the output of [`wwinference::wwinference()`] using:
+We can generate this directly on the output of `wwinference()` using:
 ```{r extracting-draws}
 draws_df <- get_draws(ww_fit)
 
@@ -491,7 +491,7 @@ We strongly recommend running diagnostics as a post-processing step on the
 model outputs.
 
 This can be done by passing the output of
-`wwinference()` into the `get_model_diagnostic_flags()`, `parameter_diagnostics()`,
+`wwinference()` into the `get_model_diagnostic_flags()`,
 and `parameter_diagnostics()` functions.
 
 `get_model_diagnostic_flags()` will print out a table of any flags, if any of
@@ -549,7 +549,7 @@ rely on the admissions only model if there are covergence or known data issues
 with the wastewater data.
 
 ```{r fit-hosp-only, warning=FALSE, message=FALSE}
-fit_hosp_only <- wwinference::wwinference(
+fit_hosp_only <- wwinference(
   ww_data = ww_data_to_fit,
   count_data = hosp_data_preprocessed,
   forecast_date = forecast_date,

--- a/vignettes/wwinference.Rmd
+++ b/vignettes/wwinference.Rmd
@@ -162,7 +162,7 @@ below the LOD in upstream pre-processing.
 
 ## Hospital admissions data pre-processing
 
-The `preprocess_hosp_data()`  function standardizes the column names of the
+The `preprocess_count_data()`  function standardizes the column names of the
 resulting datafame. The user must specify the name of the column containing
 the daily hospital admissions counts and the population size that the hospital
 admissions are coming from (from in this case, a hypothetical US state). The

--- a/vignettes/wwinference.Rmd
+++ b/vignettes/wwinference.Rmd
@@ -9,6 +9,7 @@ output:
     code_folding: show
 pkgdown:
   as_is: true
+link-citations: true
 vignette: >
   %\VignetteIndexEntry{Getting started with wwinference}
   %\VignetteEngine{knitr::rmarkdown}

--- a/vignettes/wwinference.Rmd
+++ b/vignettes/wwinference.Rmd
@@ -9,7 +9,6 @@ output:
     code_folding: show
 pkgdown:
   as_is: true
-link-citations: true
 vignette: >
   %\VignetteIndexEntry{Getting started with wwinference}
   %\VignetteEngine{knitr::rmarkdown}


### PR DESCRIPTION
Edited:
The reason things weren't linking is just that they weren't formatted properly. Link citations only necessary if you have a bibliograph (which we don't)