### PR TITLE
Hot fix validate pmf

### DIFF
--- a/R/validate.R
+++ b/R/validate.R
@@ -235,7 +235,7 @@ validate_pmf <- function(pmf,
                          count_data,
                          arg = "x",
                          call = rlang::caller_env()) {
-  if (!all.equal(sum(pmf), 1)) {
+  if (!isTRUE(all.equal(sum(pmf), 1))) {
     cli::cli_abort(
       c(
         "{.arg {arg}} does not sum to 1."

--- a/R/validate.R
+++ b/R/validate.R
@@ -235,7 +235,7 @@ validate_pmf <- function(pmf,
                          count_data,
                          arg = "x",
                          call = rlang::caller_env()) {
-  if (!isTRUE(all.equal(sum(pmf), 1))) {
+  if (!isTRUE(all.equal(sum(pmf), 1, tolerance = 1e-6))) {
     cli::cli_abort(
       c(
         "{.arg {arg}} does not sum to 1."

--- a/R/validate.R
+++ b/R/validate.R
@@ -227,12 +227,15 @@ validate_both_datasets <- function(input_count_data,
 #' @param calibration_time integer indicating the calibration time
 #' @param count_data tibble containing the input count data ready to be passed
 #' to stan
+#' @param tolerance numeric indicating the allowable difference between the
+#' sum of the pmf and 1, default is `1e-6`
 #' @param arg name of the argument supplying the object
 #' @param call The calling environment to be reflected in the error message
 #' @return NULL, invisibly
 validate_pmf <- function(pmf,
                          calibration_time,
                          count_data,
+                         tolerance = 1e-6,
                          arg = "x",
                          call = rlang::caller_env()) {
   if (!isTRUE(all.equal(sum(pmf), 1, tolerance = 1e-6))) {

--- a/man/validate_pmf.Rd
+++ b/man/validate_pmf.Rd
@@ -10,6 +10,7 @@ validate_pmf(
   pmf,
   calibration_time,
   count_data,
+  tolerance = 1e-06,
   arg = "x",
   call = rlang::caller_env()
 )
@@ -22,6 +23,9 @@ each day}
 
 \item{count_data}{tibble containing the input count data ready to be passed
 to stan}
+
+\item{tolerance}{numeric indicating the allowable difference between the
+sum of the pmf and 1, default is \code{1e-6}}
 
 \item{arg}{name of the argument supplying the object}
 

--- a/tests/testthat/test_checkers.R
+++ b/tests/testthat/test_checkers.R
@@ -270,6 +270,16 @@ test_that(
 )
 
 test_that(
+  "Test that validate pmfs returns the expected error message.",
+  {
+    invalid_pmf <- c(0.4, 0.4, 0.4)
+    expect_error(validate_pmf(invalid_pmf),
+      regexp = "does not sum to 1"
+    )
+  }
+)
+
+test_that(
   "Test that assert dates in range function works as expected.",
   {
     dates1 <- lubridate::ymd(c("2023-01-01", "2023-01-02"))


### PR DESCRIPTION
This PR does two things, one which is necessary another which may be up for discussion but does appear to be necessary if we are passing in  long pmfs through a config... 
1. Fix the `validate_pmf()` function. `all.equal()` needs to be wrapped in `isTRUE()` because it returns either TRUE or a character with difference (alternatively we could use that error message here, but I like our custom one). https://www.rdocumentation.org/packages/base/versions/3.6.2/topics/all.equal
2. Adds a test so that we catch something like this next time 

The up for debate thing is that:
1. Adjusting the tolerance. I loaded from the package data and passed to the config and I think passing things around leads to rounding error, so the long infection to hospital admissions delay has a difference of just above 1e-7. I think we should be a bit more flexible with this given we are setting this up for people to pass in delays via a config. 

Open to other suggestions e.g. for the pipeline we could one off load the rda from the `wwinference` package, use the package default, or compute directly but in general I think we want the `wwinference` package to allow users to specify via a config a long delay so tolerance can be a bit higher IMO. 