### PR TITLE
hot-fix initialization misspecifies parameter name for `error_rt_subpop`

### DIFF
--- a/R/initialization.R
+++ b/R/initialization.R
@@ -105,7 +105,7 @@ get_inits_for_one_chain <- function(stan_data, stdev = 0.01) {
   )
 
   if (stan_data$n_subpops > 1) {
-    init_list$error_subpop <- matrix(
+    init_list$error_rt_subpop <- matrix(
       stats::rnorm((n_subpops - 1) * n_weeks,
         mean = 0,
         sd = stdev


### PR DESCRIPTION
Looks like I accidentally misnamed the initialization of the `error_rt_subpop` in `initialization.R` to `error_subpop`. I don't think our CI caught this bc it just prints as a stan warning, like the other stan warnings that we routinely ignore as the sampler is warming up :)