### PR TITLE
Hot fix warn if data exceeds forecast date

### DIFF
--- a/R/checkers.R
+++ b/R/checkers.R
@@ -587,7 +587,8 @@ assert_dates_within_frame <- function(dates1,
   if (!check_dates2_win_frame) {
     cli::cli_abort(
       c(
-        "The two vectors of dates do not overlap",
+        "The two vectors of dates do not overlap or the data is outside ",
+        "the forecast period",
         add_err_msg
       ),
       call = call,

--- a/R/get_stan_data.R
+++ b/R/get_stan_data.R
@@ -21,7 +21,7 @@ get_input_count_data_for_stan <- function(preprocessed_count_data,
     )
 
   if (max(lubridate::ymd(
-    input_count_data$date
+    input_count_data_filtered$date
   )) > lubridate::ymd(forecast_date)) {
     cli::cli_warn(
       c(

--- a/R/wwinference.R
+++ b/R/wwinference.R
@@ -204,7 +204,8 @@ wwinference <- function(ww_data,
   # Get the input count data that will get passed directly to stan
   input_count_data <- get_input_count_data_for_stan(
     count_data,
-    calibration_time
+    calibration_time,
+    forecast_date
   )
   last_count_data_date <- max(input_count_data$date, na.rm = TRUE)
   first_count_data_date <- min(input_count_data$date, na.rm = TRUE)
@@ -214,7 +215,8 @@ wwinference <- function(ww_data,
     ww_data,
     first_count_data_date,
     last_count_data_date,
-    calibration_time
+    calibration_time,
+    forecast_date
   )
   # Get the table that maps 1-indexed time to dates
   date_time_spine <- get_date_time_spine(

--- a/man/get_input_count_data_for_stan.Rd
+++ b/man/get_input_count_data_for_stan.Rd
@@ -4,7 +4,11 @@
 \alias{get_input_count_data_for_stan}
 \title{Get the input count data to pass directly to stan}
 \usage{
-get_input_count_data_for_stan(preprocessed_count_data, calibration_time)
+get_input_count_data_for_stan(
+  preprocessed_count_data,
+  calibration_time,
+  forecast_date
+)
 }
 \arguments{
 \item{preprocessed_count_data}{a dataframe with the input count data, must
@@ -12,9 +16,12 @@ have the following columns: date, count, total_pop}
 
 \item{calibration_time}{integer indicating the max duration in days that
 the model is calibrated to the count data for}
+
+\item{forecast_date}{a character string in ISO8601 format (YYYY-MM-DD)
+indicating the date that the forecast is to be made. Default is NULL}
 }
 \value{
-datatframe of count data passed to stan
+dataframe of count data passed to stan
 }
 \description{
 Get the input count data to pass directly to stan

--- a/man/get_input_ww_data_for_stan.Rd
+++ b/man/get_input_ww_data_for_stan.Rd
@@ -8,7 +8,8 @@ get_input_ww_data_for_stan(
   preprocessed_ww_data,
   first_count_data_date,
   last_count_data_date,
-  calibration_time
+  calibration_time,
+  forecast_date
 )
 }
 \arguments{
@@ -25,6 +26,9 @@ presen, in ISO8601 format (YYYY-MM-DD)}
 
 \item{calibration_time}{integer indicating the max duration in days that
 the model is calibrated to the count data for}
+
+\item{forecast_date}{a character string in ISO8601 format (YYYY-MM-DD)
+indicating the date that the forecast is to be made. Default is NULL}
 }
 \value{
 dataframe of the ww data passed to stan

--- a/tests/testthat/test_get_stan_data.R
+++ b/tests/testthat/test_get_stan_data.R
@@ -54,7 +54,8 @@ include_ww <- 1
 
 input_count_data <- get_input_count_data_for_stan(
   count_data,
-  calibration_time
+  calibration_time,
+  forecast_date
 )
 first_count_data_date <- min(input_count_data$date, na.rm = TRUE)
 last_count_data_date <- max(input_count_data$date, na.rm = TRUE)
@@ -62,7 +63,8 @@ input_ww_data <- get_input_ww_data_for_stan(
   ww_data_filtered,
   first_count_data_date,
   last_count_data_date,
-  calibration_time
+  calibration_time,
+  forecast_date
 )
 date_time_spine <- get_date_time_spine(
   forecast_date = forecast_date,
@@ -258,7 +260,8 @@ test_that(paste0(
     ww_data_no_exclusions,
     first_count_data_date,
     last_count_data_date,
-    calibration_time
+    calibration_time,
+    forecast_date
   )
 
   expect_true(nrow(input_ww_data_ne) == nrow(input_ww_data))
@@ -269,7 +272,8 @@ test_that(paste0(
     ww_data_w_exclusions,
     first_count_data_date,
     last_count_data_date,
-    calibration_time
+    calibration_time,
+    forecast_date
   )
 
   expect_true(nrow(input_ww_data_ne) == nrow(input_ww_data_we) + 1)
@@ -307,7 +311,8 @@ test_that(paste0(
     recent_input_ww_data,
     first_count_data_date,
     last_count_data_date,
-    calibration_time
+    calibration_time,
+    forecast_date
   )
   date_time_spine <- get_date_time_spine(
     forecast_date = forecast_date,
@@ -377,7 +382,8 @@ test_that(paste0(
     old_input_ww_data,
     first_count_data_date,
     last_count_data_date,
-    calibration_time
+    calibration_time,
+    forecast_date
   )
   date_time_spine <- get_date_time_spine(
     forecast_date = forecast_date,

--- a/tests/testthat/test_get_stan_data.R
+++ b/tests/testthat/test_get_stan_data.R
@@ -244,7 +244,8 @@ test_that(paste0(
 ), {
   result <- get_input_count_data_for_stan(
     count_data,
-    calibration_time = 80
+    calibration_time = 80,
+    forecast_date
   )
   expect_true(nrow(result) == 80)
 })


### PR DESCRIPTION
This came up while troubleshooting implementation with @hannahcohen4. 

The issue is right now it is on the user to make sure the data doesn't exceed the forecast date. Instead, I think we should still let them run the model, truncate the data, and give them a warning that we strongly recommend that vintaged datasets be used for retrospective forecasts. 

Curious others thoughts on this (it could also error). The point is just that as it is implemented this would only error in the `assert_dates_within_frame()`. We could modify this to be more verbose about which frame the data is not within (in this case, failed the check of being before than the forecast date).