### PR TITLE
Fix error messaging when data extends beyond forecast date

### DIFF
--- a/R/checkers.R
+++ b/R/checkers.R
@@ -588,7 +588,10 @@ assert_dates_within_frame <- function(dates1,
   checkmate::assert_date(dates1)
   checkmate::assert_date(dates2)
   check_dates2_win_frame <- min(dates1) <= max(dates2) &
-    min(dates2) >= min(dates1)
+    min(dates2) >= min(dates1) &
+    min(dates2) <= max(dates1) &
+    min(dates1) >= min(dates2)
+
   if (!check_dates2_win_frame) {
     cli::cli_abort(
       c(

--- a/R/checkers.R
+++ b/R/checkers.R
@@ -13,19 +13,26 @@
 #' @param date_vector vector of dates
 #' @param max_date string indicating the maximum date in ISO8601 convention
 #' e.g. YYYY-MM-DD
+#' @param arg_dates string to print the name of the data you are checking the
+#' dates for
+#' @param arg_max_date string to print the name of the maximum date you are
+#' checkign the data for
 #' @param call Calling environment to be passed to [cli::cli_abort()] for
 #' traceback.
 #'
 #' @return NULL, invisibly
 assert_no_dates_after_max <- function(date_vector,
-                                      max_date, call = rlang::caller_env()) {
+                                      max_date,
+                                      arg_dates = "y",
+                                      arg_max_date = "x",
+                                      call = rlang::caller_env()) {
   if (max(date_vector) > max_date) {
     cli::cli_abort(
       c(
-        "The data passed in has observations beyond the specified",
-        "maximum date. Either this is the incorrect vintaged",
-        "data, or the data needs to be filtered to only contain",
-        "observations before the maximum date"
+        "The {.arg_dates {arg_dates}} passed in has observations beyond the",
+        " specified {.arg_max_date {arg_max_date}}. Either this is the ",
+        "incorrect vintaged data, or the data needs to be filtered to only ",
+        "contain observations before the {.arg_max_date {arg_max_date}}"
       ),
       call = call,
       class = "wwinference_input_data_error"
@@ -581,9 +588,7 @@ assert_dates_within_frame <- function(dates1,
   checkmate::assert_date(dates1)
   checkmate::assert_date(dates2)
   check_dates2_win_frame <- min(dates1) <= max(dates2) &
-    min(dates2) >= min(dates1) &
-    max(dates2) <= max_date &
-    max(dates1) <= max_date
+    min(dates2) >= min(dates1)
   if (!check_dates2_win_frame) {
     cli::cli_abort(
       c(
@@ -597,6 +602,8 @@ assert_dates_within_frame <- function(dates1,
 
   invisible()
 }
+
+
 #' Assert that two tibbles of date and time mapping align
 #'
 #' @param first_data a tibble containing the columns `date` (with IS08601

--- a/R/checkers.R
+++ b/R/checkers.R
@@ -588,9 +588,7 @@ assert_dates_within_frame <- function(dates1,
   checkmate::assert_date(dates1)
   checkmate::assert_date(dates2)
   check_dates2_win_frame <- min(dates1) <= max(dates2) &
-    min(dates2) >= min(dates1) &
-    min(dates2) <= max(dates1) &
-    min(dates1) >= min(dates2)
+    min(dates2) <= max(dates1)
 
   if (!check_dates2_win_frame) {
     cli::cli_abort(

--- a/R/checkers.R
+++ b/R/checkers.R
@@ -31,7 +31,8 @@ assert_no_dates_after_max <- function(date_vector,
       c(
         "The {.arg_dates {arg_dates}} passed in has observations after the ",
         "specified {.arg_max_date {arg_max_date}}. Check that this is the ",
-        "dataset you intended to use with the given {.arg_max_date {arg_max_date}}."
+        "dataset you intended to use with the given ",
+        "{.arg_max_date {arg_max_date}}."
       ),
       call = call,
       class = "wwinference_input_data_error"

--- a/R/checkers.R
+++ b/R/checkers.R
@@ -29,10 +29,9 @@ assert_no_dates_after_max <- function(date_vector,
   if (max(date_vector) > max_date) {
     cli::cli_abort(
       c(
-        "The {.arg_dates {arg_dates}} passed in has observations beyond the",
-        " specified {.arg_max_date {arg_max_date}}. Either this is the ",
-        "incorrect vintaged data, or the data needs to be filtered to only ",
-        "contain observations before the {.arg_max_date {arg_max_date}}"
+        "The {.arg_dates {arg_dates}} passed in has observations after the ",
+        "specified {.arg_max_date {arg_max_date}}. Check that this is the ",
+        "dataset you intended to use with the given {.arg_max_date {arg_max_date}}."
       ),
       call = call,
       class = "wwinference_input_data_error"

--- a/R/get_stan_data.R
+++ b/R/get_stan_data.R
@@ -423,6 +423,14 @@ get_stan_data <- function(input_count_data,
     arg = "infection to count delay"
   )
 
+  # Check that count data doesn't extend beyond forecast date
+  assert_no_dates_after_max(
+    date_vector = input_count_data$date,
+    max_date = forecast_date,
+    arg_dates = "wastewater data",
+    arg_max_date = "forecast date"
+  )
+
   # Validate both datasets if both are used----------------------------------
   if (include_ww == 1) {
     validate_both_datasets(
@@ -434,6 +442,13 @@ get_stan_data <- function(input_count_data,
       lab_site_subpop_spine = lab_site_subpop_spine,
       calibration_time = calibration_time,
       forecast_date = forecast_date
+    )
+    # Check that ww data doesn't extend beyond forecast date
+    assert_no_dates_after_max(
+      date_vector = input_ww_data$date,
+      max_date = forecast_date,
+      arg_dates = "wastewater data",
+      arg_max_date = "forecast date"
     )
   }
 

--- a/man/assert_no_dates_after_max.Rd
+++ b/man/assert_no_dates_after_max.Rd
@@ -4,13 +4,25 @@
 \alias{assert_no_dates_after_max}
 \title{Check that all dates in dataframe passed in are before a specified date}
 \usage{
-assert_no_dates_after_max(date_vector, max_date, call = rlang::caller_env())
+assert_no_dates_after_max(
+  date_vector,
+  max_date,
+  arg_dates = "y",
+  arg_max_date = "x",
+  call = rlang::caller_env()
+)
 }
 \arguments{
 \item{date_vector}{vector of dates}
 
 \item{max_date}{string indicating the maximum date in ISO8601 convention
 e.g. YYYY-MM-DD}
+
+\item{arg_dates}{string to print the name of the data you are checking the
+dates for}
+
+\item{arg_max_date}{string to print the name of the maximum date you are
+checkign the data for}
 
 \item{call}{Calling environment to be passed to \code{\link[cli:cli_abort]{cli::cli_abort()}} for
 traceback.}

--- a/tests/testthat/test_checkers.R
+++ b/tests/testthat/test_checkers.R
@@ -12,11 +12,23 @@ test_that(
 
     max_date <- lubridate::ymd("2024-01-02")
 
-    expect_error(assert_no_dates_after_max(date_vector, max_date))
+    expect_error(
+      assert_no_dates_after_max(date_vector, max_date,
+        arg_dates = "example data",
+        arg_max_date = "maximum date"
+      ),
+      regexp = "The example data passed in has observations"
+    )
 
     max_date <- "character"
 
-    expect_error(assert_no_dates_after_max(date_vector, max_date))
+    expect_error(
+      assert_no_dates_after_max(date_vector, max_date,
+        arg_dates = "example data",
+        arg_max_date = "maximum date"
+      ),
+      regexp = "The example data passed in has observations"
+    )
   }
 )
 

--- a/tests/testthat/test_checkers.R
+++ b/tests/testthat/test_checkers.R
@@ -296,39 +296,16 @@ test_that(
   {
     dates1 <- lubridate::ymd(c("2023-01-01", "2023-01-02"))
     dates2 <- lubridate::ymd(c("2023-01-01", "2023-01-04"))
-    max_date <- "2023-01-05"
     expect_no_error(assert_dates_within_frame(
       dates1,
-      dates2,
-      max_date
-    ))
-
-
-    dates1 <- lubridate::ymd(c("2023-01-01", "2023-01-02"))
-    dates2 <- lubridate::ymd(c("2023-01-03", "2023-01-04"))
-    max_date <- "2023-01-05"
-    expect_no_error(assert_dates_within_frame(
-      dates1,
-      dates2,
-      max_date
+      dates2
     ))
 
     dates1 <- lubridate::ymd(c("2023-01-01", "2023-01-02"))
     dates2 <- lubridate::ymd(c("2024-01-03", "2024-01-04"))
-    max_date <- "2023-01-05"
     expect_error(assert_dates_within_frame(
       dates1,
-      dates2,
-      max_date
-    ))
-
-    dates1 <- lubridate::ymd(c("2023-01-01", "2023-01-02"))
-    dates2 <- lubridate::ymd(c("2023-01-03", "2023-01-04"))
-    max_date <- "2022-01-05"
-    expect_error(assert_dates_within_frame(
-      dates1,
-      dates2,
-      max_date
+      dates2
     ))
   }
 )

--- a/tests/testthat/test_checkers.R
+++ b/tests/testthat/test_checkers.R
@@ -20,7 +20,7 @@ test_that(
       regexp = "The example data passed in has observations"
     )
 
-    max_date <- "character"
+    max_date <- as.character("2024-01-02")
 
     expect_error(
       assert_no_dates_after_max(date_vector, max_date,


### PR DESCRIPTION
This PR closes #202. It uses the `assert_no_dates_after_max()` check (that wasn't being used, since we removed needing to specify the forecast date from the preprocessing steps!). What it does:
- runs the assertion on the wastewater and count data within the `wwinference()` function
- updates the `assert_no_dates_after_max()` to take in args specifying what data is in the date vector and what the max date is
- updates the test of `assert_no_dates_after_max()` to expect the specific error message written