### PR TITLE
Modify infection feedback prior

### DIFF
--- a/inst/extdata/example_params.toml
+++ b/inst/extdata/example_params.toml
@@ -42,8 +42,8 @@ offset_ref_initial_exp_growth_rate_prior_sd = 0.025
 autoreg_p_hosp_a = 1 # shape1 parameter of autoreg term on IHR(t) trend
 autoreg_p_hosp_b = 100 # shape2 parameter of autoreg term on IHR(t) trend
 eta_sd_sd = 0.01
-infection_feedback_prior_logmean = 6.37408 # log(mode) + q^2 mode = 500, q = 0.4
-infection_feedback_prior_logsd = 0.4
+infection_feedback_prior_logmean = 0 # log(mode) + q^2 mode = 500, q = 0.4
+infection_feedback_prior_logsd = 3
 
 [hospital_admission_observation_process]
 # Hospitalization parameters (informative priors)

--- a/inst/extdata/example_params.toml
+++ b/inst/extdata/example_params.toml
@@ -42,7 +42,7 @@ offset_ref_initial_exp_growth_rate_prior_sd = 0.025
 autoreg_p_hosp_a = 1 # shape1 parameter of autoreg term on IHR(t) trend
 autoreg_p_hosp_b = 100 # shape2 parameter of autoreg term on IHR(t) trend
 eta_sd_sd = 0.01
-infection_feedback_prior_logmean = 0 # log(mode) + q^2 mode = 500, q = 0.4
+infection_feedback_prior_logmean = 0 # log(mode) + q^2 mode = 1, q = 0.3
 infection_feedback_prior_logsd = 3
 
 [hospital_admission_observation_process]


### PR DESCRIPTION
Originally was N(500,200) so lognormal(6, 0.4) which was a VERY strong infection feedback forcing term, especially at high incidence. 

This PR proposes changing this prior to be centered around 1 but in the range of o to 400 (exp(6) ~ 400). 

We plan to test this our in the `wweval` pipeline, look at performance, and then consider adding this to a version update. 