### PR TITLE
Replacing artifact and setting retention days to 7

### DIFF
--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -193,6 +193,8 @@ jobs:
 
   post-page-artifact:
     runs-on: ubuntu-latest
+    
+    if: ${{ github.event_name == 'pull_request' }}
 
     # This job depends on the `build` job
     needs: combine
@@ -206,7 +208,6 @@ jobs:
       # Post the artifact pulling the id from the `readme` step.
       # The msg will refer to the arfitact as 'README file'.
       - name: Post the artifact
-        if: ${{ github.event_name == 'pull_request' }}
         uses: CDCgov/cfa-actions/post-artifact@v1.0.0
         with:
           artifact-name: github-pages

--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -171,6 +171,8 @@ jobs:
         uses: actions/upload-pages-artifact@v3
         with:
           path: ./docs/
+          name: github-pages
+          retention-days: 7
 
   deploy:
     # check builds on PRs but only deploy when main changes
@@ -190,31 +192,22 @@ jobs:
         uses: actions/deploy-pages@v4
 
   post-page-artifact:
-    # only comment on PRs
-    if: ${{ github.event_name == 'pull_request' }}
-    needs: combine
     runs-on: ubuntu-latest
-    permissions:
-        contents: read
-        pull-requests: write
-    env:
-      GH_TOKEN: ${{ github.token }}
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-      - name: Find Comment
-        uses: peter-evans/find-comment@v3
-        id: fc
-        with:
-           issue-number: ${{ github.event.pull_request.number }}
-           comment-author: 'github-actions[bot]'
-           body-includes: Your page is ready to preview
 
-      - name: Create or update comment
-        uses: peter-evans/create-or-update-comment@v4
+    # This job depends on the `build` job
+    needs: combine
+
+    # Required permissions
+    permissions:
+      contents: read
+      pull-requests: write
+
+    steps:
+      # Post the artifact pulling the id from the `readme` step.
+      # The msg will refer to the arfitact as 'README file'.
+      - name: Post the artifact
+        if: ${{ github.event_name == 'pull_request' }}
+        uses: CDCgov/cfa-actions/post-artifact@v1.0.0
         with:
-          comment-id: ${{ steps.fc.outputs.comment-id }}
-          issue-number: ${{ github.event.pull_request.number }}
-          body: |
-            Thank you for your contribution, @${{ github.triggering_actor }} :rocket:! Your page is ready to preview [here](https://github.com/${{github.repository}}/actions/runs/${{ github.run_id }}/artifacts/${{ needs.build.outputs.page_artifact_id }})
-          edit-mode: replace
+          artifact-name: github-pages
+          gh-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -193,7 +193,7 @@ jobs:
 
   post-page-artifact:
     runs-on: ubuntu-latest
-    
+
     if: ${{ github.event_name == 'pull_request' }}
 
     # This job depends on the `build` job

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,9 @@
+# wwinference 0.1.0.99 (dev)
+
+## Internal changes
+
+- Updated the workflow for posting the pages artifact to PRs (issue [#229](https://github.com/CDCgov/ww-inference-model/issues/229)).
+
 # wwinference 0.1.0
 
 This is the first major release, focused on providing an initial version of the package.


### PR DESCRIPTION
This pull request includes updates to the GitHub Actions workflow and documentation for the `wwinference` package. The most important changes involve modifying the workflow for posting pages artifacts to pull requests and updating the `NEWS.md` file to reflect these internal changes.

### Workflow Updates:

* [`.github/workflows/pkgdown.yaml`](diffhunk://#diff-eb3d51fe47cf000aab65c6172c06d12a34ae765221529a05451295d5e9149e80R174-R175): Added `name` and `retention-days` to the `upload-pages-artifact` step to specify the artifact name and retention period (7 days now).
* [`.github/workflows/pkgdown.yaml`](diffhunk://#diff-eb3d51fe47cf000aab65c6172c06d12a34ae765221529a05451295d5e9149e80L193-R213): Simplified the `post-page-artifact` job by removing unnecessary steps and using `CDCgov/cfa-actions/post-artifact` to post the artifact with the name `github-pages`.

### Documentation Updates:

* [`NEWS.md`](diffhunk://#diff-51920e95310ebfbc1ae31709f3b95f89afffbf4f1a6e38e8b2b406e2fb6197eaR1-R6): Added an entry under the development version `wwinference 0.1.0.99` to document the internal changes related to the workflow update for posting pages artifacts to pull requests.