### PR TITLE
[Hot fix] test when pop size is not constant was failing

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,7 +2,7 @@
 
 ## User-visible changes
 
-- `wwinference` now checks whether `site_pop` is unique per site (see issue [#223](https://github.com/CDCgov/ww-inference-model/issues/226) and reported by [@akeyel](https://github.com/akeyel)).
+- `wwinference` now checks whether `site_pop` is fixed per site (see issue [#223](https://github.com/CDCgov/ww-inference-model/issues/226) and reported by [@akeyel](https://github.com/akeyel)).
 
 ## Internal changes
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,7 +2,7 @@
 
 ## User-visible changes
 
-- `wwinference` now checks whether `site_pop` is fixed per site (see issue [#223](https://github.com/CDCgov/ww-inference-model/issues/226) and reported by [@akeyel](https://github.com/akeyel)).
+- `wwinference` now checks whether `site_pop` is fixed per site (see issue [#223](https://github.com/CDCgov/ww-inference-model/issues/226) reported by [@akeyel](https://github.com/akeyel)).
 
 ## Internal changes
 

--- a/tests/testthat/test_preprocess_ww_data.R
+++ b/tests/testthat/test_preprocess_ww_data.R
@@ -381,10 +381,8 @@ test_that("Function handles LOD values equal to concentration values", {
 })
 
 test_that("Constant population per site", {
-  wrong_pop <- cbind(
-    ww_data,
-    ww_data |> dplyr::mutate(site = "wrong pop")
-  )
+  wrong_pop <- ww_data
+
   wrong_pop$site_pop <- 1e6 + seq_len(nrow(ww_data))
 
   expect_error(

--- a/tests/testthat/test_preprocess_ww_data.R
+++ b/tests/testthat/test_preprocess_ww_data.R
@@ -383,7 +383,7 @@ test_that("Function handles LOD values equal to concentration values", {
 test_that("Constant population per site", {
   wrong_pop <- cbind(
     ww_data,
-    ww_data |> dplyr::mutate(site = max(.data$site) + 1)
+    ww_data |> dplyr::mutate(site = "wrong pop")
   )
   wrong_pop$site_pop <- 1e6 + seq_len(nrow(ww_data))
 

--- a/tests/testthat/test_preprocess_ww_data.R
+++ b/tests/testthat/test_preprocess_ww_data.R
@@ -381,12 +381,15 @@ test_that("Function handles LOD values equal to concentration values", {
 })
 
 test_that("Constant population per site", {
-  wrong_pop <- ww_data
-  ww_data$site_pop <- 1e6 + seq_len(nrow(ww_data))
+  wrong_pop <- cbind(
+    ww_data,
+    ww_data |> dplyr::mutate(site = max(.data$site) + 1)
+  )
+  wrong_pop$site_pop <- 1e6 + seq_len(nrow(ww_data))
 
   expect_error(
     preprocess_ww_data(
-      ww_data,
+      wrong_pop,
       conc_col_name = "conc",
       lod_col_name = "lod"
     ),

--- a/tests/testthat/test_preprocess_ww_data.R
+++ b/tests/testthat/test_preprocess_ww_data.R
@@ -382,7 +382,7 @@ test_that("Function handles LOD values equal to concentration values", {
 
 test_that("Constant population per site", {
   wrong_pop <- ww_data
-  ww_data$site_pop <- sample(ww_data$site_pop)
+  ww_data$site_pop <- 1e6 + seq_len(nrow(ww_data))
 
   expect_error(
     preprocess_ww_data(


### PR DESCRIPTION
Removed sampling of size pop and added an arbitrary site_pop value to ensure the pre_processing fails (passing the test 😋)