### PR TITLE
Issue 238: Fix plot bug

### DIFF
--- a/R/figures.R
+++ b/R/figures.R
@@ -57,7 +57,6 @@ get_plot_forecasted_counts <- function(draws,
       aes(x = .data$date, y = .data$pred_value, group = .data$draw),
       color = "red4", alpha = 0.1, linewidth = 0.2
     ) +
-    geom_point(aes(x = .data$date, y = .data$observed_value)) +
     geom_vline(
       xintercept = lubridate::ymd(forecast_date),
       linetype = "dashed"
@@ -91,7 +90,10 @@ get_plot_forecasted_counts <- function(draws,
         shape = 21, color = "black", fill = "white"
       )
   }
-  return(p)
+  # Add calibration data as final step, this should be plotted on top of
+  # the eval data(if present) and draws
+  p <- p + geom_point(aes(x = .data$date, y = .data$observed_value)) +
+    return(p)
 }
 
 #' Get plot of fit and forecasted wastewater concentrations

--- a/R/figures.R
+++ b/R/figures.R
@@ -92,8 +92,9 @@ get_plot_forecasted_counts <- function(draws,
   }
   # Add calibration data as final step, this should be plotted on top of
   # the eval data(if present) and draws
-  p <- p + geom_point(aes(x = .data$date, y = .data$observed_value)) +
-    return(p)
+  p_final <- p + geom_point(aes(x = .data$date, y = .data$observed_value))
+
+  return(p_final)
 }
 
 #' Get plot of fit and forecasted wastewater concentrations


### PR DESCRIPTION
Currently the eval data gets added if present after the observation data and draws. The data the model is calibrated to is in the closed circles. and we want this to be in front of the white open circle eval data.

Note, I chose not to just cut off the eval data in the nowcast/forecast period, because there are changes in the values in the calibration period sometimes too, and we want these to be visible. 