### PR TITLE
Issue 245: fix y-axis scaling on `subpop_rt` plot

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,7 @@
 - Add wastewater data into the forecast period to output in `generate_simulated_data()` function and as package data. Also adds subpopulation-level
 hospital admissions to output of function and package data. ([#184](https://github.com/CDCgov/ww-inference-model/issues/184))
 - `wwinference` now checks whether `site_pop` is fixed per site (see issue [#223](https://github.com/CDCgov/ww-inference-model/issues/226) reported by [@akeyel](https://github.com/akeyel)).
+- `get_plot_subpop_rt()` now uses a shared y-axis to facilitate comparison of R(t) estimates) ([#245](https://github.com/CDCgov/ww-inference-model/issues/245))
 
 ## Internal changes
 - Updated the workflow for posting the pages artifact to PRs (issue [#229](https://github.com/CDCgov/ww-inference-model/issues/229)).

--- a/R/figures.R
+++ b/R/figures.R
@@ -268,7 +268,7 @@ get_plot_subpop_rt <- function(draws,
       linetype = "dashed",
       show.legend = FALSE
     ) +
-    facet_wrap(~subpop_name, scales = "free") +
+    facet_wrap(~subpop_name) +
     geom_hline(aes(yintercept = 1), linetype = "dashed") +
     xlab("") +
     ylab("Subpopulation R(t)") +


### PR DESCRIPTION
This pull request includes a modification to the `get_plot_subpop_rt` function in `R/figures.R` to improve data visualization.

Codebase improvements:

* [`R/figures.R`](diffhunk://#diff-f7089033e5a0a78960b1f9e9a33f23d411e328263b45844b4dc111636c445c49L271-R271): Modified the `get_plot_subpop_rt` function to use a shared y-axis by removing the `scales = "free"` parameter from `facet_wrap`.