### PR TITLE
Tweaks to model definition

### DIFF
--- a/model_definition.md
+++ b/model_definition.md
@@ -62,10 +62,10 @@ We model infection dynamics in these subpopulations hierarchically: subpopulatio
 #### Subpopulation definition
 The total population consists of $K_\mathrm{total}$ subpopulations $k$ with corresponding population sizes $n_k$. We associate one subpopulation to each of the $K_\mathrm{sites}$ wastewater sampling sites in the jurisdiction and assign that subpopulation a population size $n_k$ equal to the population size reported for that wastewater catchment area.
 
-Whenever the sum of the wastewater catchment population sizes $\sum\nolimits_{k=1}^{K_\mathrm{sites}} n_k$ is less than the total population size $n$, we use an additional subpopulation of size $n - \sum\nolimits_{k=1}^{K_\mathrm{sites}} n_k$ to model individuals in the population who are not covered by wastewater sampling. 
-In this case, we refer to the subpopulation not covered by wastewater as the reference subpopulation, denoted by $k=0$. 
+Whenever the sum of the wastewater catchment population sizes $\sum\nolimits_{k=1}^{K_\mathrm{sites}} n_k$ is less than the total population size $n$, we use an additional subpopulation of size $n - \sum\nolimits_{k=1}^{K_\mathrm{sites}} n_k$ to model individuals in the population who are not covered by wastewater sampling.
+In this case, we refer to the subpopulation not covered by wastewater as the reference subpopulation, denoted by $k=0$.
 
-The total number of subpopulations is then $K_\mathrm{total} = K_\mathrm{sites} + 1$: the subpopulation to account for individuals not covered by wastewater sampling plus the $K_\mathrm{sites}$ subpopulations with sampled wastewater. 
+The total number of subpopulations is then $K_\mathrm{total} = K_\mathrm{sites} + 1$: the subpopulation to account for individuals not covered by wastewater sampling plus the $K_\mathrm{sites}$ subpopulations with sampled wastewater.
 
 The model without wastewater (hospital admissions only model) is therefore a special case of the model where $K_\mathrm{sites} = 0$ and $K_\mathrm{total} = 1$, with subpopulation size $n_k = n$, the total population.
 

--- a/model_definition.md
+++ b/model_definition.md
@@ -69,7 +69,7 @@ The total number of subpopulations is then $K_\mathrm{total} = K_\mathrm{sites} 
 
 The model without wastewater (hospital admissions only model) is therefore a special case of the model where $K_\mathrm{sites} = 0$ and $K_\mathrm{total} = 1$, with subpopulation size $n_k = n$, the total population.
 
-In the case where the sum of the wastewater site catchment populations meets or exceeds the total population ($\sum\nolimits_{k=1}^{K_\mathrm{sites}} n_k \ge n$) the model does not assign a subpopulation without sampled wastewater. In that case, the reference subpopulation, denoted by $k=0$ is assigned to the largest wastewater catchment area, and the total number of subpopulations is equal to the number of sites, $K_\mathrm{total} = K_\mathrm{sites}$.
+If the sum of the wastewater site catchment populations meets or exceeds the total population ($\sum\nolimits_{k=1}^{K_\mathrm{sites}} n_k \ge n$), the model does not create a subpopulation without sampled wastewater. In that case, the largest wastewater catchment area by population serves as the reference subpopulation (denoted by $k=0$), and the total number of subpopulations is equal to the number of sites, $K_\mathrm{total} = K_\mathrm{sites}$.
 
 This amounts to modeling the wastewater catchments populations as approximately non-overlapping; every infected individual either does not contribute to measured wastewater or contributes principally to one wastewater catchment.
 This approximation is reasonable if we restrict our analyses to primary wastewaster treatment plants, which avoids the possibility that an individual might be sampled once in a sample taken upstream and then sampled again in a more aggregated sample taken further downstream.

--- a/model_definition.md
+++ b/model_definition.md
@@ -64,7 +64,8 @@ The total population consists of $K_\mathrm{total}$ subpopulations $k$ with corr
 
 Whenever the sum of the wastewater catchment population sizes $\sum\nolimits_{k=1}^{K_\mathrm{sites}} n_k$ is less than the total population size $n$, we use an additional subpopulation of size $n - \sum\nolimits_{k=1}^{K_\mathrm{sites}} n_k$ to model individuals in the population who are not covered by wastewater sampling.
 
-The total number of subpopulations is then $K_\mathrm{total} = K_\mathrm{sites} + 1$: the $K_\mathrm{sites}$ subpopulations with sampled wastewater, and the final subpopulation to account for individuals not covered by wastewater sampling.
+The total number of subpopulations is then $K_\mathrm{total} = K_\mathrm{sites} + 1$: the subpopulation to account for individuals not covered by wastewater sampling plus the $K_\mathrm{sites}$ subpopulations with sampled wastewater. We refer to first subpopulation as the reference subpopulation, denoted by $k=0$.
+
 The model without wastewater (hospital admissions only model) is therefore a special case of the model where $K_\mathrm{sites} = 0$ and $K_\mathrm{total} = 1$, with subpopulation size $n_k = n$, the total population.
 In the case where the sum of the wastewater site catchment populations meets or exceeds the total population ($\sum\nolimits_{k=1}^{K_\mathrm{sites}} n_k \ge n$) the model does not use a final subpopulation without sampled wastewater. In that case, the total number of subpopulations $K_\mathrm{total} = K_\mathrm{sites}$.
 

--- a/model_definition.md
+++ b/model_definition.md
@@ -87,7 +87,7 @@ We model the subpopulations as having infection dynamics that are _similar_ to o
 
 We represent this with a hierarchical model where we estimate the reference subpopulation's un-damped effective reproductive number $\mathcal{R}^\mathrm{u}_ {0}(t)$ and then estimate the individual subpopulations $k$ deviations from the reference value, $\mathcal{R}^\mathrm{u}_{k}(t)$
 
-The refrence value for the undamped instantaneous reproductive number $\mathcal{R}^\mathrm{u}(t)$ follows the time-evolution described above.
+The reference value for the undamped instantaneous reproductive number $\mathcal{R}^\mathrm{u}(t)$ follows the time-evolution described above.
 Subpopulation deviations from the reference reproduction number are modeled via a log-scale AR(1) process. Specifically, for subpopulation $k$:
 
 $$

--- a/model_definition.md
+++ b/model_definition.md
@@ -116,7 +116,7 @@ From $\mathcal{R}_{k}(t)$, we generate values of the supopulation-level _expecte
 To obtain the number of infections per capita $I(t)$ in the total population as a whole, we sum the $K_\mathrm{total}$ subpopulation per capita infection counts $I_k(t)$ weighted by their population sizes:
 
 ```math
-I(t) = \frac{1}{\sum\nolimits_{k=1}^{K_\mathrm{total}} n_k} \sum_{k=1}^{K_\mathrm{total}} n_k I_k(t)
+I(t) = \frac{1}{\sum\nolimits_{k=0}^{K_\mathrm{total}-1} n_k} \sum_{k=0}^{K_\mathrm{total}-1} n_k I_k(t)
 ```
 
 We infer the site level initial per capita incidence $I_k(0)$ hierarchically. Specifically, we treat $\mathrm{logit}[I_k(0)]$ as Normally distributed about the corresponding jurisdiction-level value $\mathrm{logit}[I(0)]$, with an estimated standard deviation $\sigma_{i0}$:

--- a/model_definition.md
+++ b/model_definition.md
@@ -60,14 +60,16 @@ individuals who do not contribute to the sampled wastewater.
 We model infection dynamics in these subpopulations hierarchically: subpopulation infection dynamics are distributed about a central jurisdiction-level infection dynamic, and the total infections that generate the hospital admissions observations are simply the sum of the subpopulation-level infections.
 
 #### Subpopulation definition
-The total population consists of $K_\mathrm{total}$ subpopulations $k$ with corresponding population sizes $n_k$. We associate one subpopulation to each of the $K_\mathrm{sites}$ wastewater sampling sites in the jurisdiction and assign that subpopulation a population size $n_k$ equal to the wastewater catchment population size reported for that wastewater catchment area.
+The total population consists of $K_\mathrm{total}$ subpopulations $k$ with corresponding population sizes $n_k$. We associate one subpopulation to each of the $K_\mathrm{sites}$ wastewater sampling sites in the jurisdiction and assign that subpopulation a population size $n_k$ equal to the population size reported for that wastewater catchment area.
 
-Whenever the sum of the wastewater catchment population sizes $\sum\nolimits_{k=1}^{K_\mathrm{sites}} n_k$ is less than the total population size $n$, we use an additional subpopulation of size $n - \sum\nolimits_{k=1}^{K_\mathrm{sites}} n_k$ to model individuals in the population who are not covered by wastewater sampling.
+Whenever the sum of the wastewater catchment population sizes $\sum\nolimits_{k=1}^{K_\mathrm{sites}} n_k$ is less than the total population size $n$, we use an additional subpopulation of size $n - \sum\nolimits_{k=1}^{K_\mathrm{sites}} n_k$ to model individuals in the population who are not covered by wastewater sampling. 
+In this case, we refer to the subpopulation not covered by wastewater as the reference subpopulation, denoted by $k=0$. 
 
-The total number of subpopulations is then $K_\mathrm{total} = K_\mathrm{sites} + 1$: the subpopulation to account for individuals not covered by wastewater sampling plus the $K_\mathrm{sites}$ subpopulations with sampled wastewater. We refer to first subpopulation as the reference subpopulation, denoted by $k=0$.
+The total number of subpopulations is then $K_\mathrm{total} = K_\mathrm{sites} + 1$: the subpopulation to account for individuals not covered by wastewater sampling plus the $K_\mathrm{sites}$ subpopulations with sampled wastewater. 
 
 The model without wastewater (hospital admissions only model) is therefore a special case of the model where $K_\mathrm{sites} = 0$ and $K_\mathrm{total} = 1$, with subpopulation size $n_k = n$, the total population.
-In the case where the sum of the wastewater site catchment populations meets or exceeds the total population ($\sum\nolimits_{k=1}^{K_\mathrm{sites}} n_k \ge n$) the model does not use a final subpopulation without sampled wastewater. In that case, the total number of subpopulations $K_\mathrm{total} = K_\mathrm{sites}$.
+
+In the case where the sum of the wastewater site catchment populations meets or exceeds the total population ($\sum\nolimits_{k=1}^{K_\mathrm{sites}} n_k \ge n$) the model does not assign a subpopulation without sampled wastewater. In that case, the reference subpopulation, denoted by $k=0$ is assigned to the largest wastewater catchment area, and the total number of subpopulations is equal to the number of sites, $K_\mathrm{total} = K_\mathrm{sites}$.
 
 This amounts to modeling the wastewater catchments populations as approximately non-overlapping; every infected individual either does not contribute to measured wastewater or contributes principally to one wastewater catchment.
 This approximation is reasonable if we restrict our analyses to primary wastewaster treatment plants, which avoids the possibility that an individual might be sampled once in a sample taken upstream and then sampled again in a more aggregated sample taken further downstream.

--- a/model_definition.md
+++ b/model_definition.md
@@ -40,7 +40,7 @@ We decompose the instantaneous reproduction number $\mathcal{R}(t)$ into two com
 We assume that the unadjusted reproduction number $\mathcal{R}^\mathrm{u}(t)$ is a piecewise-constant function with weekly change points (i.e., if $t$ and $t'$ are days in the same week, then $\mathcal{R}^\mathrm{u}(t)$ = $\mathcal{R}^\mathrm{u}(t')$ ). To account for the dependence of the unadjusted reproduction number in a given week on the previous week, we use a differenced auto-regressive process for the log-scale reproduction number. A log-scale representation is used to ensure that the reproduction number is positive and so that week-to-week changes are multiplicative rather than additive.
 
 $$
-\log[\mathcal{R}^\mathrm{u}(t_i)] \sim \mathrm{Normal}\left(\log[\mathcal{R}^\mathrm{u}(t_{i-1})] + \beta \left(\log[\mathcal{R}^\mathrm{u}(t_{i-2})] - \log[\mathcal{R}^\mathrm{u}(t_{i-1})]\right), \sigma_r \right)
+\log[\mathcal{R}^\mathrm{u}(t_i)] \sim \mathrm{Normal}\left(\log[\mathcal{R}^\mathrm{u}(t_{i-1})] + \beta \left(\log[\mathcal{R}^\mathrm{u}(t_{i-1})] - \log[\mathcal{R}^\mathrm{u}(t_{i-2})]\right), \sigma_r \right)
 $$
 
 where $t_i$, $t_{i-1}$, and $t_{i-2}$ are days in three successive weeks, $\beta$ is an autoregression coefficient which serves to make week-to-week changes correlated, and $\sigma_r$ determines the overall variation in week-to-week changes.


### PR DESCRIPTION
This PR makes a few changes to the model definition:
- definition incorrectly stated that the subsequent R(t)s were negatively correlated
- unifying indexing in the subpopulations-- where the "reference" subpopulation is the $k=0th$ subpopulation. Therefore when we sum over subpopulations we start indexing at 0
- a typo fix